### PR TITLE
fix: clear child per click

### DIFF
--- a/packages/site/src/pages/randomizer.astro
+++ b/packages/site/src/pages/randomizer.astro
@@ -23,13 +23,20 @@
         return Array.from(cardIndexes).map((index) => cards[index]);
       }
 
+      function clearChild(element: HTMLElement): void {
+        while (element.firstChild) {
+          element.removeChild(element.firstChild);
+        }
+      }
+
       document.querySelector("button")?.addEventListener("click", () => {
         const result = document.getElementById("result");
-        const cards = getRandomCards();
         if (result == null) {
           console.error("button is not found");
           return;
         }
+        clearChild(result);
+        const cards = getRandomCards();
         for (const card of cards) {
           const cardWrapper = document.createElement("div");
           const anchor = document.createElement("a");


### PR DESCRIPTION
when click randomize button twice or over, append card over 10.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced the randomizer page by ensuring it clears previous results before displaying new random cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->