### PR TITLE
feat:  add filter rule

### DIFF
--- a/packages/card/src/assets/basic/common.json
+++ b/packages/card/src/assets/basic/common.json
@@ -191,6 +191,7 @@
     "id": 32,
     "type": "common",
     "name": "お付きの侍女",
+    "cost": 4,
     "edition": 0,
     "cards": [
       {

--- a/packages/card/src/assets/far-eastern-border/common.json
+++ b/packages/card/src/assets/far-eastern-border/common.json
@@ -283,6 +283,7 @@
     "type": "common",
     "name": "精霊契約",
     "effect": "",
+    "cost": 8,
     "edition": 1,
     "cards": [
       {

--- a/packages/card/src/type.ts
+++ b/packages/card/src/type.ts
@@ -72,6 +72,7 @@ export const isUniqueCard = is.ObjectOf({
   type: is.LiteralOf("common"),
   name: is.String,
   cards: is.ArrayOf(is.ObjectOf(cardBase)),
+  cost: is.Number,
   edition: isEdition,
 });
 

--- a/packages/site/src/pages/randomizer.astro
+++ b/packages/site/src/pages/randomizer.astro
@@ -1,7 +1,3 @@
----
-import { rules } from "../rules/index";
----
-
 <!doctype html>
 <html lang="en">
   <head>
@@ -14,30 +10,50 @@ import { rules } from "../rules/index";
       action="#"
       id="option-form"
     >
-      {
-        rules.map((r) => (
-          <div>
-            <input type="checkbox" />
-            <label>{r.description}</label>
-          </div>
-        ))
-      }
-      <button>ランダマイズ</button>
+      <button id="submit-button">ランダマイズ</button>
     </form>
     <div id="result"></div>
     <script>
-      import { Basic, FarEasternBorder } from "@heart-of-crown-randomizer/card";
+      import { commons as basic } from "@heart-of-crown-randomizer/card/basic/common";
+      import { commons as farEasternBorder } from "@heart-of-crown-randomizer/card/far-eastern-border/common";
+      import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+      import { rules } from "../rules/index";
+
+      const cards: CommonCard[] = [...basic, ...farEasternBorder];
+
+      function addOptions() {
+        const form = document.querySelector("#option-form");
+        if (form == null) {
+          console.error("form is not found");
+          return;
+        }
+        const button = document.querySelector("#submit-button");
+        if (button == null) {
+          console.error("button is not found");
+          return;
+        }
+        for (const r of rules) {
+          const div = document.createElement("div");
+          const input = document.createElement("input");
+          input.type = "checkbox";
+          input.name = r.description;
+          const label = document.createElement("label");
+          label.textContent = r.description;
+          div.appendChild(input);
+          div.appendChild(label);
+          form.insertBefore(div, button);
+        }
+      }
+
       function randint(max: number): number {
         return Math.floor(Math.random() * Math.floor(max));
       }
-      const cards = [...Basic.commons, ...FarEasternBorder.commons];
-
-      function getRandomCards() {
+      function getRandomCards(): CommonCard[] {
         const cardIndexes = new Set<number>();
         while (cardIndexes.size < 10) {
           cardIndexes.add(randint(cards.length));
         }
-        return Array.from(cardIndexes).map((index) => cards[index]);
+        return Array.from(cardIndexes).map((index) => cards[index]!);
       }
 
       function clearChild(element: HTMLElement): void {
@@ -46,22 +62,49 @@ import { rules } from "../rules/index";
         }
       }
 
+      addOptions();
+
       document
-        .querySelector("#option-form")
-        ?.addEventListener("submit", (e: Event) => {
+        .querySelector<HTMLFormElement>("#option-form")
+        ?.addEventListener("submit", (e: SubmitEvent) => {
           e.preventDefault();
           const result = document.getElementById("result");
           if (result == null) {
             console.error("button is not found");
             return;
           }
+          const enabledRules = rules.filter((r) => {
+            const input = document.querySelector<HTMLInputElement>(
+              `input[name="${r.description}"]`,
+            );
+            if (input == null) {
+              return false;
+            }
+            return input.checked;
+          });
           clearChild(result);
-          const cards = getRandomCards();
-          for (const card of cards) {
+          const accepts = (() => {
+            for (let i = 0; i < 10; i++) {
+              const cards = getRandomCards();
+              if (enabledRules.every((r) => r.expr(cards))) {
+                return cards;
+              }
+            }
+            return undefined;
+          })();
+
+          if (accepts === undefined) {
+            const errorText = document.createElement("p");
+            errorText.textContent = "条件に合うカードが見つかりませんでした";
+            result.appendChild(errorText);
+            return;
+          }
+
+          for (const card of accepts) {
             const cardWrapper = document.createElement("div");
             const anchor = document.createElement("a");
             anchor.href = `../cards/${card!.id}`;
-            anchor.textContent = card!.name;
+            anchor.textContent = card.name;
             cardWrapper.appendChild(anchor);
             result.appendChild(cardWrapper);
           }

--- a/packages/site/src/pages/randomizer.astro
+++ b/packages/site/src/pages/randomizer.astro
@@ -1,3 +1,7 @@
+---
+import { rules } from "../rules/index";
+---
+
 <!doctype html>
 <html lang="en">
   <head>
@@ -6,7 +10,20 @@
   </head>
   <body>
     <h1>Randomizer</h1>
-    <button>ランダマイズ</button>
+    <form
+      action="#"
+      id="option-form"
+    >
+      {
+        rules.map((r) => (
+          <div>
+            <input type="checkbox" />
+            <label>{r.description}</label>
+          </div>
+        ))
+      }
+      <button>ランダマイズ</button>
+    </form>
     <div id="result"></div>
     <script>
       import { Basic, FarEasternBorder } from "@heart-of-crown-randomizer/card";
@@ -29,23 +46,26 @@
         }
       }
 
-      document.querySelector("button")?.addEventListener("click", () => {
-        const result = document.getElementById("result");
-        if (result == null) {
-          console.error("button is not found");
-          return;
-        }
-        clearChild(result);
-        const cards = getRandomCards();
-        for (const card of cards) {
-          const cardWrapper = document.createElement("div");
-          const anchor = document.createElement("a");
-          anchor.href = `../cards/${card!.id}`;
-          anchor.textContent = card!.name;
-          cardWrapper.appendChild(anchor);
-          result.appendChild(cardWrapper);
-        }
-      });
+      document
+        .querySelector("#option-form")
+        ?.addEventListener("submit", (e: Event) => {
+          e.preventDefault();
+          const result = document.getElementById("result");
+          if (result == null) {
+            console.error("button is not found");
+            return;
+          }
+          clearChild(result);
+          const cards = getRandomCards();
+          for (const card of cards) {
+            const cardWrapper = document.createElement("div");
+            const anchor = document.createElement("a");
+            anchor.href = `../cards/${card!.id}`;
+            anchor.textContent = card!.name;
+            cardWrapper.appendChild(anchor);
+            result.appendChild(cardWrapper);
+          }
+        });
     </script>
   </body>
 </html>

--- a/packages/site/src/rules/include-all-cost.ts
+++ b/packages/site/src/rules/include-all-cost.ts
@@ -1,0 +1,13 @@
+import { type CommonCard } from "@heart-of-crown-randomizer/card/type";
+import type { Rule } from "./type";
+
+export const rule: Rule = {
+  description:
+    "各コスト帯のカードを1枚以上含めるようにします。ただし6コスト以上のカードは5コスト帯として扱います。",
+  expr: (cards: CommonCard[]) => {
+    const costs = new Set<number>(
+      cards.map((card) => (card.cost > 5 ? 5 : card.cost)),
+    );
+    return costs.size === 4;
+  },
+};

--- a/packages/site/src/rules/include-all-cost.ts
+++ b/packages/site/src/rules/include-all-cost.ts
@@ -1,6 +1,9 @@
 import { type CommonCard } from "@heart-of-crown-randomizer/card/type";
 import type { Rule } from "./type";
 
+// NOTE: This rule is based on:
+// https://github.com/kana/hatokurandom/blob/22cf98853340394f2d53a1c59cfab80d438aca36/lib/utils.js#L1518
+
 export const rule: Rule = {
   description:
     "各コスト帯のカードを1枚以上含めるようにします。ただし6コスト以上のカードは5コスト帯として扱います。",

--- a/packages/site/src/rules/index.ts
+++ b/packages/site/src/rules/index.ts
@@ -1,0 +1,3 @@
+import { rule as zeroWithTwo } from "./zero-with-two.ts";
+
+export const rules = [zeroWithTwo];

--- a/packages/site/src/rules/index.ts
+++ b/packages/site/src/rules/index.ts
@@ -1,3 +1,4 @@
 import { rule as zeroWithTwo } from "./zero-with-two.ts";
+import { rule as includeAllCost } from "./include-all-cost.ts";
 
-export const rules = [zeroWithTwo];
+export const rules = [zeroWithTwo, includeAllCost];

--- a/packages/site/src/rules/type.ts
+++ b/packages/site/src/rules/type.ts
@@ -1,0 +1,6 @@
+import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+
+export type Rule = {
+  description: string;
+  expr: (cards: CommonCard[]) => boolean;
+};

--- a/packages/site/src/rules/zero-with-two.ts
+++ b/packages/site/src/rules/zero-with-two.ts
@@ -7,7 +7,8 @@ import type { Rule } from "./type";
 function someHas(cards: CommonCard[], link: number): boolean {
   return cards.some((card) => {
     if (isUniqueCard(card)) {
-      return card.cards.some((c) => c.link === link);
+      // NOTE: unique card is treats as no link
+      return false;
     }
     return card.link === link;
   });

--- a/packages/site/src/rules/zero-with-two.ts
+++ b/packages/site/src/rules/zero-with-two.ts
@@ -4,6 +4,12 @@ import {
 } from "@heart-of-crown-randomizer/card/type";
 import type { Rule } from "./type";
 
+/**
+ * Check cards has some links
+ * @param cards Cards to check
+ * @param link Number of links
+ * @returns True if cards has some links
+ */
 function someHas(cards: CommonCard[], link: number): boolean {
   return cards.some((card) => {
     if (isUniqueCard(card)) {

--- a/packages/site/src/rules/zero-with-two.ts
+++ b/packages/site/src/rules/zero-with-two.ts
@@ -1,0 +1,26 @@
+import {
+  type CommonCard,
+  isUniqueCard,
+} from "@heart-of-crown-randomizer/card/type";
+import type { Rule } from "./type";
+
+function someHas(cards: CommonCard[], link: number): boolean {
+  return cards.some((card) => {
+    if (isUniqueCard(card)) {
+      return card.cards.some((c) => c.link === link);
+    }
+    return card.link === link;
+  });
+}
+
+export const rule: Rule = {
+  description:
+    "サプライにリンク0のカードが含まれる場合、リンク2のカードを1枚は含めるようにする。",
+  expr: (cards: CommonCard[]) => {
+    const hasZero = someHas(cards, 0);
+    if (!hasZero) {
+      return true;
+    }
+    return someHas(cards, 2);
+  },
+};

--- a/packages/site/src/rules/zero-with-two.ts
+++ b/packages/site/src/rules/zero-with-two.ts
@@ -20,6 +20,9 @@ function someHas(cards: CommonCard[], link: number): boolean {
   });
 }
 
+// NOTE: This rule is based on:
+// https://github.com/kana/hatokurandom/blob/22cf98853340394f2d53a1c59cfab80d438aca36/lib/utils.js#L1509
+
 export const rule: Rule = {
   description:
     "サプライにリンク0のカードが含まれる場合、リンク2のカードを1枚は含めるようにする。",


### PR DESCRIPTION
## Summary

ランダマイズする時のフィルタ条件を追加

## Detail

- 各コストを含めるルールを追加
- 0リンクが含まれる時は2リンクも含めるルールを追加
- ランダマイズ時に設定されているルールを適用して生成する機能を追加
  - 暫定で最大10回回す
- 複数種のカードを持つカードのトップレベルにコストを持つようにschemaを修正
  - 現状では複数コストになるカードはないので多分大丈夫
  - 1版にもなさそうなので追加される可能性は低そう？