### PR TITLE
ci: add enable renovate auto-merge task

### DIFF
--- a/.github/workflows/enable-renovate-auto-merge.yml
+++ b/.github/workflows/enable-renovate-auto-merge.yml
@@ -1,0 +1,19 @@
+name: Enable auto merge
+
+on:
+  - pull_request
+
+jobs:
+  enable-auto-merge:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    if: |
+      ! failure() && ! cancelled() && github.event.pull_request.user.login == 'renovate[bot]' && contains(github.event.pull_request.body, ' **Automerge**: Enabled.')
+    steps:
+      - uses: suzuki-shunsuke/enable-auto-merge-action@fc3173c4dac9254ee191d89f1f8b257bbefc4e31 # main
+        with:
+          pr_number: ${{github.event.pull_request.number}}
+          merge_method: squash
+          github_token: ${{github.token}}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Introduced a new GitHub Actions workflow to automatically merge pull requests from the Renovate bot, streamlining dependency updates and reducing manual intervention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->