### PR TITLE
ci: enhance ci

### DIFF
--- a/.github/workflows/_check-actions.yml
+++ b/.github/workflows/_check-actions.yml
@@ -1,8 +1,6 @@
-name: Lint github actions
+name: Check github action
 
-on:
-  - push
-  - pull_request
+on: workflow_call
 
 jobs:
   linting:
@@ -12,20 +10,10 @@ jobs:
     steps:
       - name: checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
-      - name: Check Changed Files
-        uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
-        id: filter
-        with:
-          filters: |
-            actions:
-              - .github/workflows/*
-              - aqua.yaml
       - uses: aquaproj/aqua-installer@6ce1f8848ec8e61f14d57bd5d7597057a6dd187c # v3.0.1
-        if: steps.filter.outputs.actions == 'true'
         with:
           aqua_version: v2.28.1
       - name: Lint github actions
-        if: steps.filter.outputs.actions == 'true'
         run: |
           actionlint -color
           ghalint run

--- a/.github/workflows/_check-code.yml
+++ b/.github/workflows/_check-code.yml
@@ -1,7 +1,6 @@
-name: basic ci
+name: Check based npm
 
-on:
-  - push
+on: workflow_call
 
 jobs:
   basic:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,55 @@
+name: Checks for pull request
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  path-filter:
+    outputs:
+      actions: ${{steps.changes.outputs.actions}}
+      ts: ${{steps.changes.outputs.ts}}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            actions:
+              - .github/workflows/*.yml
+              - .github/workflows/*.yaml
+              - aqua.yaml
+            ts:
+              - .github/workflows/pull-request.yml
+              - pnpm-lock.yml
+              - pnpm-workspace.yaml
+              - turbo.json
+              - biome.json
+              - ./**/package.json
+              - ./**/tsconfig.json
+              - ./**/vite.config.ts
+              - packages/card/src/**/*
+  check-actions:
+    needs: path-filter
+    if: needs.path-filter.outputs.actions == 'true'
+    uses: ./.github/workflows/_check-actions.yml
+    permissions:
+      contents: read
+  check-typescript:
+    needs: path-filter
+    if: needs.path-filter.outputs.ts == 'true'
+    uses: ./.github/workflows/_check-code.yml
+    permissions:
+      contents: read
+  status-check:
+    runs-on: ubuntu-latest
+    needs:
+      - check-actions
+      - check-typescript
+    permissions: {}
+    if: failure()
+    steps:
+      - run: exit 1

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,44 @@
+
+name: Checks for push
+
+on: push
+
+jobs:
+  path-filter:
+    outputs:
+      actions: ${{steps.changes.outputs.actions}}
+      ts: ${{steps.changes.outputs.ts}}
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changes
+        with:
+          filters: |
+            actions:
+              - .github/workflows/*.yml
+              - .github/workflows/*.yaml
+              - aqua.yaml
+            ts:
+              - .github/workflows/push.yml
+              - pnpm-lock.yml
+              - pnpm-workspace.yaml
+              - turbo.json
+              - biome.json
+              - ./**/package.json
+              - ./**/tsconfig.json
+              - ./**/vite.config.ts
+              - packages/card/src/**/*
+  check-actions:
+    needs: path-filter
+    if: needs.path-filter.outputs.actions == 'true'
+    uses: ./.github/workflows/_check-actions.yml
+    permissions:
+      contents: read
+  check-typescript:
+    needs: path-filter
+    if: needs.path-filter.outputs.ts == 'true'
+    uses: ./.github/workflows/_check-code.yml
+    permissions:
+      contents: read


### PR DESCRIPTION
Add `status-check` job for branch protection.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new GitHub Actions workflow for checking pull requests on the `main` branch, enhancing the CI/CD pipeline.

- **Changes**
  - Updated existing GitHub Actions workflows to be triggered by `workflow_call` instead of `push` and `pull_request`. 
  - Renamed workflows for better clarity:
    - "Lint github actions" to "Check github action"
    - "basic ci" to "Check based npm"

<!-- end of auto-generated comment: release notes by coderabbit.ai -->