### PR TITLE
ci: update matrix

### DIFF
--- a/.github/workflows/_check-code.yml
+++ b/.github/workflows/_check-code.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["20", "lts", "current"]
+        node: ["20", "lts/*", "current"]
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6

--- a/.github/workflows/_check-code.yml
+++ b/.github/workflows/_check-code.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["18", "20", "latest"]
+        node: ["20", "lts", "current"]
     steps:
       - name: Checkout
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -24,6 +24,7 @@ jobs:
               - aqua.yaml
             ts:
               - .github/workflows/pull-request.yml
+              - .github/workflows/_check-code.yml
               - pnpm-lock.yml
               - pnpm-workspace.yaml
               - turbo.json

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -22,6 +22,7 @@ jobs:
               - aqua.yaml
             ts:
               - .github/workflows/push.yml
+              - .github/workflows/_check-code.yml
               - pnpm-lock.yml
               - pnpm-workspace.yaml
               - turbo.json


### PR DESCRIPTION
node18 is dropped from lts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated Node versions in GitHub Actions workflow to ensure compatibility with latest Node releases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->