### PR TITLE
ci: use node22

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -6,7 +6,6 @@ on:
     branches:
       - main
 
-
 jobs:
   path-filter:
     timeout-minutes: 5
@@ -63,7 +62,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node: ["20", "lts/*", "current"]
+        node: ["22", "lts/*", "current"]
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated automated workflow to test with Node.js version 22 instead of 20.
  - Minor cleanup of workflow configuration formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->