### PR TITLE
test: add storybook stories and autodocs for all components

### DIFF
--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -1,0 +1,45 @@
+name: Deploy Storybook to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5.0.0
+      - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version: lts/*
+          cache: pnpm
+      - run: pnpm install
+      - run: pnpm --filter=@heart-of-crown-randomizer/site run build-storybook
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
+        with:
+          path: packages/site/storybook-static
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac553fd0d28 # v4.0.5

--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -5,10 +5,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
-  pages: write
-  id-token: write
+permissions: {}
 
 concurrency:
   group: pages
@@ -16,6 +13,8 @@ concurrency:
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -34,6 +33,9 @@ jobs:
           path: packages/site/storybook-static
 
   deploy:
+    permissions:
+      pages: write
+      id-token: write
     needs: build
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/packages/site/.storybook/main.ts
+++ b/packages/site/.storybook/main.ts
@@ -2,7 +2,11 @@ import type { StorybookConfig } from "@storybook/sveltekit";
 
 const config = {
   stories: ["../src/**/*.mdx", "../src/**/*.stories.@(js|ts|svelte)"],
-  addons: ["@storybook/addon-svelte-csf", "@storybook/addon-interactions"],
+  addons: [
+    "@storybook/addon-svelte-csf",
+    "@storybook/addon-docs",
+    "@storybook/addon-interactions",
+  ],
   framework: {
     name: "@storybook/sveltekit",
     options: {},

--- a/packages/site/.storybook/preview.ts
+++ b/packages/site/.storybook/preview.ts
@@ -1,6 +1,7 @@
 import type { Preview } from "@storybook/svelte";
 
 const preview: Preview = {
+  tags: ["autodocs"],
   parameters: {
     controls: {
       matchers: {

--- a/packages/site/package.json
+++ b/packages/site/package.json
@@ -29,6 +29,7 @@
 	"devDependencies": {
 		"@biomejs/biome": "catalog:",
 		"@playwright/test": "1.59.1",
+		"@storybook/addon-docs": "10.3.5",
 		"@storybook/addon-interactions": "8.6.14",
 		"@storybook/addon-svelte-csf": "5.1.2",
 		"@storybook/svelte": "10.3.4",

--- a/packages/site/src/lib/CardDetail.stories.svelte
+++ b/packages/site/src/lib/CardDetail.stories.svelte
@@ -1,0 +1,92 @@
+<script
+	module
+	lang="ts"
+>
+	import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+	import { Edition } from "@heart-of-crown-randomizer/card/type";
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import { fn } from "@storybook/test";
+	import CardDetail from "./CardDetail.svelte";
+
+	const actionCard: CommonCard = {
+		id: 1,
+		type: "common",
+		name: "Sample Action Card",
+		cost: 3,
+		hasChild: false,
+		mainType: ["action"],
+		link: 1,
+		effect: "Draw 2 cards from the deck.",
+		edition: Edition.BASIC,
+	};
+
+	const coinCard: CommonCard = {
+		id: 2,
+		type: "common",
+		name: "Merchant Ship",
+		cost: 5,
+		hasChild: false,
+		mainType: ["territory"],
+		link: 0,
+		coin: 3,
+		effect: "Produces 3 coins.",
+		edition: Edition.BASIC,
+	};
+
+	const successionCard: CommonCard = {
+		id: 3,
+		type: "common",
+		name: "Royal Estate",
+		cost: 6,
+		hasChild: false,
+		mainType: ["succession"],
+		succession: 3,
+		link: 0,
+		effect: "Worth 3 succession points.",
+		edition: Edition.BASIC,
+	};
+
+	const attackCard: CommonCard = {
+		id: 4,
+		type: "common",
+		name: "Raid",
+		cost: 4,
+		hasChild: false,
+		mainType: ["action", "attack"],
+		link: 1,
+		effect: "Each other player discards 1 card from hand.",
+		edition: Edition.FAR_EASTERN_BORDER,
+	};
+
+	const { Story } = defineMeta({
+		title: "Components/CardDetail",
+		component: CardDetail,
+		parameters: {
+			docs: {
+				description: {
+					component: "Displays detailed card information in a bottom sheet dialog.",
+				},
+			},
+		},
+	});
+</script>
+
+<Story
+	name="Default"
+	args={{ card: actionCard, onClose: fn() }}
+/>
+
+<Story
+	name="WithCoin"
+	args={{ card: coinCard, onClose: fn() }}
+/>
+
+<Story
+	name="WithSuccession"
+	args={{ card: successionCard, onClose: fn() }}
+/>
+
+<Story
+	name="AttackCard"
+	args={{ card: attackCard, onClose: fn() }}
+/>

--- a/packages/site/src/lib/ConstraintPanel.stories.svelte
+++ b/packages/site/src/lib/ConstraintPanel.stories.svelte
@@ -1,0 +1,84 @@
+<script
+	module
+	lang="ts"
+>
+	import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+	import { Edition } from "@heart-of-crown-randomizer/card/type";
+	import type { Constraint, SelectionContext } from "@heart-of-crown-randomizer/constraint";
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import ConstraintPanel from "./ConstraintPanel.svelte";
+
+	const sampleCards: CommonCard[] = [
+		{
+			id: 1,
+			type: "common",
+			name: "Sample Card A",
+			cost: 3,
+			hasChild: false,
+			mainType: ["action"],
+			link: 1,
+			effect: "Example effect A",
+			edition: Edition.BASIC,
+		},
+		{
+			id: 2,
+			type: "common",
+			name: "Sample Card B",
+			cost: 5,
+			hasChild: false,
+			mainType: ["action"],
+			link: 2,
+			effect: "Example effect B",
+			edition: Edition.BASIC,
+		},
+	];
+
+	const sampleConstraints: Constraint[] = [
+		{
+			id: 1,
+			label: "コスト3以下を含む",
+			canApply: () => true,
+			apply: (ctx: SelectionContext) => ctx,
+			isSatisfied: () => true,
+		},
+		{
+			id: 2,
+			label: "リンク2以上を含む",
+			canApply: () => true,
+			apply: (ctx: SelectionContext) => ctx,
+			isSatisfied: () => true,
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "Components/ConstraintPanel",
+		component: ConstraintPanel,
+		parameters: {
+			docs: {
+				description: {
+					component: "Panel for toggling card selection constraints.",
+				},
+			},
+		},
+	});
+</script>
+
+<Story
+	name="Default"
+	args={{
+		constraints: sampleConstraints,
+		allCards: sampleCards,
+		excludedIds: new Set(),
+		count: 10,
+	}}
+/>
+
+<Story
+	name="Empty"
+	args={{
+		constraints: [],
+		allCards: sampleCards,
+		excludedIds: new Set(),
+		count: 10,
+	}}
+/>

--- a/packages/site/src/lib/DebugPanel.stories.svelte
+++ b/packages/site/src/lib/DebugPanel.stories.svelte
@@ -1,0 +1,98 @@
+<script
+	module
+	lang="ts"
+>
+	import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+	import { Edition } from "@heart-of-crown-randomizer/card/type";
+	import type { Constraint, SelectionContext } from "@heart-of-crown-randomizer/constraint";
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import DebugPanel from "./DebugPanel.svelte";
+
+	const sampleCards: CommonCard[] = [
+		{
+			id: 1,
+			type: "common",
+			name: "隠れ家",
+			cost: 2,
+			hasChild: false,
+			mainType: ["action"],
+			link: 1,
+			effect: "Example effect",
+			edition: Edition.BASIC,
+		},
+		{
+			id: 2,
+			type: "common",
+			name: "都市開発",
+			cost: 3,
+			hasChild: false,
+			mainType: ["action"],
+			link: 0,
+			effect: "Example effect",
+			edition: Edition.BASIC,
+		},
+		{
+			id: 3,
+			type: "common",
+			name: "交易船",
+			cost: 4,
+			hasChild: false,
+			mainType: ["action"],
+			link: 1,
+			effect: "Example effect",
+			edition: Edition.BASIC,
+		},
+		{
+			id: 4,
+			type: "common",
+			name: "魔法の絨毯",
+			cost: 5,
+			hasChild: false,
+			mainType: ["action"],
+			link: 2,
+			effect: "Example effect",
+			edition: Edition.FAR_EASTERN_BORDER,
+		},
+	];
+
+	const sampleConstraints: Constraint[] = [
+		{
+			id: 1,
+			label: "コスト2〜5",
+			canApply: (_context: Readonly<SelectionContext>) => true,
+			apply: (context: SelectionContext) => context,
+			isSatisfied: (_cards: readonly CommonCard[]) => true,
+		},
+		{
+			id: 2,
+			label: "リンクあり",
+			canApply: (_context: Readonly<SelectionContext>) => true,
+			apply: (context: SelectionContext) => context,
+			isSatisfied: (_cards: readonly CommonCard[]) => false,
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "Components/DebugPanel",
+		component: DebugPanel,
+		parameters: {
+			docs: {
+				description: {
+					component: "Debug panel showing constraint status and card pool details.",
+				},
+			},
+		},
+	});
+</script>
+
+<Story
+	name="Default"
+	args={{
+		constraints: sampleConstraints,
+		selectedCards: [sampleCards[0], sampleCards[2]],
+		allCards: sampleCards,
+		pinnedCards: [sampleCards[0]],
+		excludedIds: new Set([4]),
+		count: 10,
+	}}
+/>

--- a/packages/site/src/lib/ExcludeList.stories.svelte
+++ b/packages/site/src/lib/ExcludeList.stories.svelte
@@ -1,0 +1,71 @@
+<script
+	module
+	lang="ts"
+>
+	import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+	import { Edition } from "@heart-of-crown-randomizer/card/type";
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import ExcludeList from "./ExcludeList.svelte";
+
+	const sampleCards: CommonCard[] = [
+		{
+			id: 1,
+			type: "common",
+			name: "隠れ家",
+			cost: 2,
+			hasChild: false,
+			mainType: ["action"],
+			link: 1,
+			effect: "Example",
+			edition: Edition.BASIC,
+		},
+		{
+			id: 2,
+			type: "common",
+			name: "呪詛の魔女",
+			cost: 4,
+			hasChild: false,
+			mainType: ["attack"],
+			link: 0,
+			effect: "Example",
+			edition: Edition.BASIC,
+		},
+		{
+			id: 3,
+			type: "common",
+			name: "大都市",
+			cost: 5,
+			hasChild: false,
+			mainType: ["territory"],
+			link: 2,
+			effect: "Example",
+			edition: Edition.FAR_EASTERN_BORDER,
+		},
+	];
+
+	const { Story } = defineMeta({
+		title: "Components/ExcludeList",
+		component: ExcludeList,
+		parameters: {
+			docs: {
+				description: {
+					component: "Collapsible list displaying excluded cards with option to restore them.",
+				},
+			},
+		},
+	});
+</script>
+
+<Story
+	name="Default"
+	args={{
+		cards: sampleCards,
+	}}
+/>
+
+<Story
+	name="Empty"
+	args={{
+		cards: [],
+	}}
+/>

--- a/packages/site/src/lib/app-menu/AppMenu.stories.svelte
+++ b/packages/site/src/lib/app-menu/AppMenu.stories.svelte
@@ -1,0 +1,29 @@
+<script
+	module
+	lang="ts"
+>
+	import { defineMeta } from "@storybook/addon-svelte-csf";
+	import AppMenu from "./AppMenu.svelte";
+
+	const { Story } = defineMeta({
+		title: "Components/AppMenu",
+		component: AppMenu,
+		parameters: {
+			docs: {
+				description: {
+					component: "Application menu with bug report functionality.",
+				},
+			},
+		},
+	});
+</script>
+
+<Story
+	name="Default"
+	args={{
+		selectedCardIds: [1, 3, 5, 7],
+		pinnedIds: new Set([1, 3]),
+		excludedIds: new Set([10, 20]),
+		constraintIds: new Set([5]),
+	}}
+/>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -221,6 +221,9 @@ importers:
       '@playwright/test':
         specifier: 1.59.1
         version: 1.59.1
+      '@storybook/addon-docs':
+        specifier: 10.3.5
+        version: 10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1))
       '@storybook/addon-interactions':
         specifier: 8.6.14
         version: 8.6.14(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
@@ -1124,6 +1127,12 @@ packages:
   '@kvs/types@2.2.2':
     resolution: {integrity: sha512-5lmBuah+wOdypBf0O9t6BoHrnq5hX5MlhEPTDPBNKN38ayQwVc5gYgJOBR3Dg4EF7OwL+1c7JNtWXQEJXXVXlg==}
 
+  '@mdx-js/react@3.1.1':
+    resolution: {integrity: sha512-f++rKLQgUVYDAtECQ6fn/is15GkEH9+nZPM3MS0RcxVqoTfawHvDlSCH7JbMhAM6uJ32v3eXLvLmLvjGu7PTQw==}
+    peerDependencies:
+      '@types/react': '>=16'
+      react: '>=16'
+
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
     engines: {node: '>=18'}
@@ -1372,6 +1381,11 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@storybook/addon-docs@10.3.5':
+    resolution: {integrity: sha512-WuHbxia/o5TX4Rg/IFD0641K5qId/Nk0dxhmAUNoFs5L0+yfZUwh65XOBbzXqrkYmYmcVID4v7cgDRmzstQNkA==}
+    peerDependencies:
+      storybook: ^10.3.5
+
   '@storybook/addon-interactions@8.6.14':
     resolution: {integrity: sha512-8VmElhm2XOjh22l/dO4UmXxNOolGhNiSpBcls2pqWSraVh4a670EyYBZsHpkXqfNHo2YgKyZN3C91+9zfH79qQ==}
     peerDependencies:
@@ -1410,6 +1424,24 @@ packages:
       webpack:
         optional: true
 
+  '@storybook/csf-plugin@10.3.5':
+    resolution: {integrity: sha512-qlEzNKxOjq86pvrbuMwiGD/bylnsXk1dg7ve0j77YFjEEchqtl7qTlrXvFdNaLA89GhW6D/EV6eOCu/eobPDgw==}
+    peerDependencies:
+      esbuild: '*'
+      rollup: '*'
+      storybook: ^10.3.5
+      vite: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      esbuild:
+        optional: true
+      rollup:
+        optional: true
+      vite:
+        optional: true
+      webpack:
+        optional: true
+
   '@storybook/csf@0.1.13':
     resolution: {integrity: sha512-7xOOwCLGB3ebM87eemep89MYRFTko+D8qE7EdAAq74lgdqRR5cOUtYWJLjO2dLtP94nqoOdHJo6MdLLKzg412Q==}
 
@@ -1431,6 +1463,13 @@ packages:
     resolution: {integrity: sha512-TvHR/+yyIAOp/1bLulFai2kkhIBtAlBw7J6Jd9DKyInoGhTWNE1G1Y61jD5GWXX29AlwaHfzGUaX5NL1K+FJpg==}
     peerDependencies:
       storybook: ^8.6.15
+
+  '@storybook/react-dom-shim@10.3.5':
+    resolution: {integrity: sha512-Gw8R7XZm0zSUH0XAuxlQJhmizsLzyD6x00KOlP6l7oW9eQHXGfxg3seNDG3WrSAcW07iP1/P422kuiriQlOv7g==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      storybook: ^10.3.5
 
   '@storybook/svelte-vite@10.3.4':
     resolution: {integrity: sha512-/a1Xup1I7QcPEtjkV17SqDvWXl0xUiZew5y/6S22hO3W17pboQZsE+TqVq580y3rQgKxH9e2ZcGFbgZhIo1BSg==}
@@ -1759,11 +1798,17 @@ packages:
   '@types/mdast@3.0.15':
     resolution: {integrity: sha512-LnwD+mUEfxWMa1QpDraczIn6k0Ee3SMicuYSSzS6ZYl2gKS09EClnJYGd8Du6rfc5r/GZEk5o1mRb8TaTj03sQ==}
 
+  '@types/mdx@2.0.13':
+    resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
+
   '@types/node@24.12.2':
     resolution: {integrity: sha512-A1sre26ke7HDIuY/M23nd9gfB+nrmhtYyMINbjI1zHJxYteKR6qSMX56FsmjMcDb3SMcjJg5BiRRgOCC/yBD0g==}
 
   '@types/normalize-package-data@2.4.4':
     resolution: {integrity: sha512-37i+OaWTh9qeK4LSHPsyRC7NahnGotNuZvjLSgcPzblpHB3rrCJxAOgI5gCdKm7coonsaX1Of0ILiTcnZjbfxA==}
+
+  '@types/react@19.2.14':
+    resolution: {integrity: sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==}
 
   '@types/seedrandom@3.0.8':
     resolution: {integrity: sha512-TY1eezMU2zH2ozQoAFAQFOPpvP15g+ZgSfTZt31AUUH/Rxtnz3H+A/Sv1Snw2/amp//omibc+AEkTaA8KUeOLQ==}
@@ -2139,6 +2184,9 @@ packages:
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
   data-urls@7.0.0:
     resolution: {integrity: sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==}
@@ -4570,6 +4618,12 @@ snapshots:
 
   '@kvs/types@2.2.2': {}
 
+  '@mdx-js/react@3.1.1(@types/react@19.2.14)(react@19.2.4)':
+    dependencies:
+      '@types/mdx': 2.0.13
+      '@types/react': 19.2.14
+      react: 19.2.4
+
   '@modelcontextprotocol/sdk@1.29.0(zod@3.25.76)':
     dependencies:
       '@hono/node-server': 1.19.12(hono@4.12.10)
@@ -4741,6 +4795,23 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@storybook/addon-docs@10.3.5(@types/react@19.2.14)(esbuild@0.27.7)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      '@mdx-js/react': 3.1.1(@types/react@19.2.14)(react@19.2.4)
+      '@storybook/csf-plugin': 10.3.5(esbuild@0.27.7)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1))
+      '@storybook/icons': 2.0.1(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      '@storybook/react-dom-shim': 10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
+      storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      ts-dedent: 2.2.0
+    transitivePeerDependencies:
+      - '@types/react'
+      - esbuild
+      - rollup
+      - vite
+      - webpack
+
   '@storybook/addon-interactions@8.6.14(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
     dependencies:
       '@storybook/global': 5.0.0
@@ -4786,6 +4857,14 @@ snapshots:
       esbuild: 0.27.7
       vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)
 
+  '@storybook/csf-plugin@10.3.5(esbuild@0.27.7)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1))':
+    dependencies:
+      storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      unplugin: 2.3.11
+    optionalDependencies:
+      esbuild: 0.27.7
+      vite: 8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)
+
   '@storybook/csf@0.1.13':
     dependencies:
       type-fest: 2.19.0
@@ -4807,6 +4886,12 @@ snapshots:
     dependencies:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.9
+      storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+
+  '@storybook/react-dom-shim@10.3.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))':
+    dependencies:
+      react: 19.2.4
+      react-dom: 19.2.4(react@19.2.4)
       storybook: 10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
 
   '@storybook/svelte-vite@10.3.4(@sveltejs/vite-plugin-svelte@7.0.0(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1)))(esbuild@0.27.7)(storybook@10.3.4(@testing-library/dom@10.4.1)(prettier@3.8.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(svelte@5.55.1)(vite@8.0.5(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.6.1))':
@@ -5230,11 +5315,17 @@ snapshots:
     dependencies:
       '@types/unist': 2.0.11
 
+  '@types/mdx@2.0.13': {}
+
   '@types/node@24.12.2':
     dependencies:
       undici-types: 7.16.0
 
   '@types/normalize-package-data@2.4.4': {}
+
+  '@types/react@19.2.14':
+    dependencies:
+      csstype: 3.2.3
 
   '@types/seedrandom@3.0.8': {}
 
@@ -5623,6 +5714,8 @@ snapshots:
       source-map-js: 1.2.1
 
   css.escape@1.5.1: {}
+
+  csstype@3.2.3: {}
 
   data-urls@7.0.0:
     dependencies:


### PR DESCRIPTION
## Summary

Add Storybook stories for all 5 remaining components (CardDetail, ConstraintPanel, DebugPanel, ExcludeList, AppMenu) and enable autodocs globally.

## Details

The project had Storybook configured but only the Card component had a story file. This change adds stories for every component so they can be previewed individually. Autodocs is enabled globally via `tags: ['autodocs']` in `preview.ts`, and `@storybook/addon-docs` is added as a dependency since it is required for the docs renderer. Each story includes multiple variants where meaningful (e.g., empty vs populated lists, different card types).

## Confirmation

- Run `pnpm build-storybook` in `packages/site` and verify it succeeds
- Run `pnpm storybook` and confirm all 6 components appear in the sidebar
- Navigate to the Docs tab for each component and verify autodocs renders

## Limitation

No GitHub Pages deployment workflow is included yet. That is planned as a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added interactive Storybook component stories for CardDetail, ConstraintPanel, DebugPanel, ExcludeList, and AppMenu for visual examples and testing.

* **Documentation**
  * Enabled Storybook autodocs and added the docs addon to improve component reference content.

* **Chores**
  * Added CI workflow to build and deploy the Storybook site to GitHub Pages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->