### PR TITLE
fix: build workspace dependencies before storybook build

### DIFF
--- a/.github/workflows/deploy-storybook.yaml
+++ b/.github/workflows/deploy-storybook.yaml
@@ -27,7 +27,7 @@ jobs:
           node-version: lts/*
           cache: pnpm
       - run: pnpm install
-      - run: pnpm --filter=@heart-of-crown-randomizer/site run build-storybook
+      - run: pnpm turbo run build-storybook --filter=@heart-of-crown-randomizer/site
       - uses: actions/upload-pages-artifact@7b1f4a764d45c48632c6b24a0339c27f5614fb0b # v4.0.0
         with:
           path: packages/site/storybook-static

--- a/turbo.json
+++ b/turbo.json
@@ -25,6 +25,9 @@
     "build": {
       "dependsOn": ["^build"],
       "outputs": ["dist/**", ".svelte-kit/**"]
+    },
+    "build-storybook": {
+      "dependsOn": ["^build"]
     }
   }
 }

--- a/turbo.json
+++ b/turbo.json
@@ -27,7 +27,8 @@
       "outputs": ["dist/**", ".svelte-kit/**"]
     },
     "build-storybook": {
-      "dependsOn": ["^build"]
+      "dependsOn": ["^build"],
+      "outputs": ["storybook-static/**"]
     }
   }
 }


### PR DESCRIPTION
## Summary

Fix the Storybook CI build failure by leveraging Turborepo's dependency resolution.

## Details

The `deploy-storybook.yaml` workflow ran `storybook build` directly via `pnpm --filter`, which meant workspace dependency packages (`@heart-of-crown-randomizer/card`, `@heart-of-crown-randomizer/constraint`) were never built beforehand. In CI, their `dist/` outputs did not exist, causing Rolldown to fail resolving imports like `@heart-of-crown-randomizer/card/type`.

A `build-storybook` task was added to `turbo.json` with `"dependsOn": ["^build"]`, and the workflow now calls `pnpm turbo run build-storybook` so that Turborepo automatically builds all upstream dependencies first.

## Confirmation

- The "Deploy Storybook to GitHub Pages" workflow succeeds in CI
- Locally verified: `rm -rf packages/card/dist packages/constraint/dist && pnpm turbo run build-storybook --filter=@heart-of-crown-randomizer/site` completes successfully

## Limitation

No known limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized Storybook build to run through the repository's task orchestration for more consistent execution.
  * Added a dedicated Storybook build task to improve caching and pipeline behavior.
  * Adjusted build outputs to better support incremental builds and faster CI/deploy times.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->