### PR TITLE
fix: apply global styles in storybook preview

### DIFF
--- a/packages/site/.storybook/preview.ts
+++ b/packages/site/.storybook/preview.ts
@@ -1,4 +1,5 @@
 import type { Preview } from "@storybook/svelte";
+import "../src/app.css";
 
 const preview: Preview = {
   tags: ["autodocs"],


### PR DESCRIPTION
## Summary

Import `app.css` in the Storybook preview so that CSS custom properties are available to all components.

## Details

After #1620 fixed the CI build, components rendered in Storybook were missing their styles. The CSS custom properties (`--bg-card`, `--text-primary`, `--accent-coral`, etc.) defined in `src/app.css` were not loaded in the Storybook iframe because `.storybook/preview.ts` did not import the stylesheet.

Adding `import "../src/app.css"` to `preview.ts` makes all design tokens available globally in Storybook.

## Confirmation

- Open Storybook locally (`pnpm --filter=@heart-of-crown-randomizer/site run storybook`) and verify components (Card, ExcludeList, CardDetail, etc.) render with correct colors and backgrounds

## Limitation

No known limitations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)