### PR TITLE
docs: add JSDoc to component props for Storybook autodocs

### DIFF
--- a/packages/site/src/lib/Card.svelte
+++ b/packages/site/src/lib/Card.svelte
@@ -5,12 +5,19 @@
 	import { getCategoryLabel, getStripColor, getSubTypeLabel } from "$lib/utils/card-display";
 
 	type Props = {
+		/** Card data to render */
 		card: CommonCard;
+		/** Called when a swipe gesture begins */
 		onSwipeStart: (e: MouseEvent | TouchEvent, index: number) => void;
+		/** Called during a swipe gesture */
 		onSwipeMove: (e: TouchEvent | MouseEvent) => void;
+		/** Called when a swipe gesture completes */
 		onSwipeEnd: () => void;
+		/** Called when a swipe gesture is cancelled */
 		onSwipeCancel: () => void;
+		/** Original index of this card in the list, used for swipe tracking */
 		originalIndex: number;
+		/** Called when the card is clicked */
 		onclick?: () => void;
 	};
 

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -6,7 +6,9 @@
 	import { getCategoryLabel, getStripColor } from "$lib/utils/card-display";
 
 	type Props = {
+		/** Card data to display in the detail sheet */
 		card: CommonCard;
+		/** Callback to close the detail sheet */
 		onClose: () => void;
 	};
 

--- a/packages/site/src/lib/ConstraintPanel.svelte
+++ b/packages/site/src/lib/ConstraintPanel.svelte
@@ -7,9 +7,13 @@
 	import { getEnabledConstraintIds, toggleConstraint } from "$lib/stores/constraint-state.svelte";
 
 	type Props = {
+		/** Available constraints to toggle */
 		constraints: readonly Constraint[];
+		/** All common cards in the game */
 		allCards: CommonCard[];
+		/** IDs of cards excluded from the draw pool */
 		excludedIds: ReadonlySet<number>;
+		/** Number of cards to select */
 		count: number;
 	};
 

--- a/packages/site/src/lib/DebugPanel.svelte
+++ b/packages/site/src/lib/DebugPanel.svelte
@@ -8,11 +8,17 @@
 	} from "$lib/stores/constraint-state.svelte";
 
 	type Props = {
+		/** Available constraints */
 		constraints: readonly Constraint[];
+		/** Currently selected cards from the draw */
 		selectedCards: readonly CommonCard[];
+		/** All common cards in the game */
 		allCards: CommonCard[];
+		/** Cards pinned by the user */
 		pinnedCards: CommonCard[];
+		/** IDs of cards excluded from the draw pool */
 		excludedIds: ReadonlySet<number>;
+		/** Number of cards to select */
 		count: number;
 	};
 

--- a/packages/site/src/lib/ExcludeList.svelte
+++ b/packages/site/src/lib/ExcludeList.svelte
@@ -5,6 +5,7 @@
 	import { getCategoryLabel, getStripColor } from "$lib/utils/card-display";
 
 	type Props = {
+		/** Cards currently excluded from the draw pool */
 		cards: CommonCard[];
 	};
 

--- a/packages/site/src/lib/app-menu/AppMenu.svelte
+++ b/packages/site/src/lib/app-menu/AppMenu.svelte
@@ -3,9 +3,13 @@
 	import { buildGitHubIssueUrl } from "./github-issue";
 
 	type Props = {
+		/** IDs of currently selected cards */
 		selectedCardIds: number[];
+		/** IDs of pinned cards */
 		pinnedIds: ReadonlySet<number>;
+		/** IDs of excluded cards */
 		excludedIds: ReadonlySet<number>;
+		/** IDs of enabled constraints */
 		constraintIds: ReadonlySet<number>;
 	};
 


### PR DESCRIPTION
## Summary

Add JSDoc comments to Props type fields across all Svelte components so that Storybook autodocs displays prop descriptions in the Args table.

## Details

Storybook 10.x with `@storybook/sveltekit` extracts JSDoc comments from Svelte 5 `$props()` type definitions and renders them in the autodocs Args table. Previously, the Props types had no documentation, so the Args table showed only prop names and types without descriptions. This change also includes applying global styles in the Storybook preview to match production rendering.

## Confirmation

- Run `pnpm storybook` in `packages/site/` and navigate to any component's Docs tab
- Verify that the Args table shows JSDoc descriptions in the Description column
- Confirm global styles are applied in Storybook previews

## Limitation

No known limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced component type annotations with detailed JSDoc comments across multiple interface definitions.

* **Refactor**
  * Formalized card interaction event handling with explicit callback typing for swipe and click operations, plus addition of index tracking for improved state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->