### PR TITLE
chore: specify version in devEngines.packageManager

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "devEngines": {
     "packageManager": {
       "name": "pnpm",
-      "onFail": "error"
+      "version": "10.33.0",
+      "onFail": "download"
     }
   }
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned development package manager to a specific version for consistency.
  * Updated build environment configuration to automatically download the required version when needed instead of failing with an error.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->