### PR TITLE
fix: stop showing first child's properties as parent for hasChild cards

### DIFF
--- a/packages/site/src/lib/Card.svelte
+++ b/packages/site/src/lib/Card.svelte
@@ -37,7 +37,7 @@
 
 	const stripColor = $derived(getStripColor(card));
 	const categoryLabel = $derived(getCategoryLabel(card));
-	const linkCount = $derived(card.hasChild ? (card.cards[0]?.link ?? 0) : card.link);
+	const linkCount = $derived(card.hasChild ? 0 : card.link);
 	const subTypeLabel = $derived(getSubTypeLabel(card));
 
 	function handleTogglePin(e: MouseEvent) {

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -17,15 +17,13 @@
 	const stripColor = $derived(getStripColor(card));
 	const categoryLabel = $derived(getCategoryLabel(card));
 
-	const effect = $derived(card.hasChild ? (card.cards[0]?.effect ?? "") : card.effect);
+	const effect = $derived(card.hasChild ? "" : card.effect);
 
-	const linkCount = $derived(card.hasChild ? (card.cards[0]?.link ?? 0) : card.link);
+	const linkCount = $derived(card.hasChild ? 0 : card.link);
 
-	const succession = $derived(
-		card.hasChild ? (card.cards[0]?.succession ?? undefined) : card.succession,
-	);
+	const succession = $derived(card.hasChild ? undefined : card.succession);
 
-	const coin = $derived(card.hasChild ? (card.cards[0]?.coin ?? undefined) : card.coin);
+	const coin = $derived(card.hasChild ? undefined : card.coin);
 
 	let closeButtonRef: HTMLButtonElement;
 

--- a/packages/site/src/lib/utils/card-display.ts
+++ b/packages/site/src/lib/utils/card-display.ts
@@ -23,7 +23,7 @@ const mainTypeLabels: Record<MainType, string> = {
 
 export function getMainTypes(card: CommonCard): MainType[] {
   return card.hasChild
-    ? (card.cards[0]?.mainType ?? ["action"])
+    ? [...new Set(card.cards.flatMap((c) => c.mainType))]
     : card.mainType;
 }
 


### PR DESCRIPTION
## Summary

Stop using `cards[0]` properties as parent-level values for hasChild cards, and derive `mainTypes` from all children instead of only the first.

## Details

Cards with `hasChild: true` (e.g. お付きの侍女, 精霊契約) have multiple child variants whose properties (effect, link, succession, coin, mainType) can differ. The existing code used `cards[0]` values as if they represented the parent card, which produced inaccurate displays. For example, お付きの侍女's strip color stayed indigo even though one of its children has the attack mainType.

This PR makes two changes. First, in `CardDetail.svelte` and `Card.svelte`, hasChild cards now show neutral defaults (empty effect, zero link count, no succession/coin) at the parent level, deferring per-child details to the "バリエーション" section. Second, in `getMainTypes`, the function now returns the union of all children's mainTypes via `flatMap` + `Set`, so the strip color and category label correctly reflect all variants.

## Confirmation

- Open the detail sheet for お付きの侍女: the "カード説明" section should be hidden, and all 5 variants should appear in "バリエーション."
- Open the detail sheet for 精霊契約: same behavior.
- In the card list, お付きの侍女 should have a red strip (attack type present in children).
- Normal cards (hasChild=false) should display unchanged.
- `pnpm build` succeeds.

## Limitation

No known limitations.