### PR TITLE
ci: add `id-token` permission

### DIFF
--- a/.github/workflows/auto-steering.yaml
+++ b/.github/workflows/auto-steering.yaml
@@ -11,6 +11,7 @@ jobs:
     environment: release
     permissions:
       contents: read
+      id-token: write
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2


### PR DESCRIPTION
> Action failed with error: Could not fetch an OIDC token.
> Did you remember to add `id-token: write` to your workflow permissions?
