### PR TITLE
feat: display distinct colors for cards with multiple MainTypes

### DIFF
--- a/packages/site/src/app.css
+++ b/packages/site/src/app.css
@@ -4,9 +4,7 @@
   --accent-coral: #ff6b6b;
   --accent-green: #22c55e;
   --accent-indigo: #6366f1;
-  --accent-pink: #ec4899;
   --accent-red: #ef4444;
-  --accent-silver: #94a3b8;
   --card-action: #6366f1;
   --card-attack: #ef4444;
   --card-disaster: #ff6b6b;

--- a/packages/site/src/app.css
+++ b/packages/site/src/app.css
@@ -7,6 +7,12 @@
   --accent-pink: #ec4899;
   --accent-red: #ef4444;
   --accent-silver: #94a3b8;
+  --card-action: #6366f1;
+  --card-attack: #ef4444;
+  --card-disaster: #ff6b6b;
+  --card-princess: #ec4899;
+  --card-succession: #94a3b8;
+  --card-territory: #22c55e;
   --bg-accent-coral-light: #fff0f0;
   --bg-accent-green-light: #dcfce7;
   --bg-accent-indigo-light: #e0e7ff;

--- a/packages/site/src/app.css
+++ b/packages/site/src/app.css
@@ -9,8 +9,8 @@
   --card-attack: #ef4444;
   --card-disaster: #ff6b6b;
   --card-princess: #ec4899;
-  --card-succession: #94a3b8;
-  --card-territory: #22c55e;
+  --card-succession: #22c55e;
+  --card-territory: #a16207;
   --bg-accent-coral-light: #fff0f0;
   --bg-accent-green-light: #dcfce7;
   --bg-accent-indigo-light: #e0e7ff;

--- a/packages/site/src/app.css
+++ b/packages/site/src/app.css
@@ -4,7 +4,9 @@
   --accent-coral: #ff6b6b;
   --accent-green: #22c55e;
   --accent-indigo: #6366f1;
+  --accent-pink: #ec4899;
   --accent-red: #ef4444;
+  --accent-silver: #94a3b8;
   --bg-accent-coral-light: #fff0f0;
   --bg-accent-green-light: #dcfce7;
   --bg-accent-indigo-light: #e0e7ff;

--- a/packages/site/src/lib/Card.svelte
+++ b/packages/site/src/lib/Card.svelte
@@ -2,7 +2,7 @@
 	import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
 	import { Ban, Pin } from "lucide-svelte";
 	import { getCardState, toggleExclude, togglePin } from "$lib/stores/card-state.svelte";
-	import { getCategoryLabels, getStripColors, getSubTypeLabel } from "$lib/utils/card-display";
+	import { getCategoryLabels, getSubTypeLabel } from "$lib/utils/card-display";
 
 	type Props = {
 		/** Card data to render */
@@ -35,7 +35,6 @@
 	const isPinned = $derived(state === "pinned");
 	const isExcluded = $derived(state === "excluded");
 
-	const stripColors = $derived(getStripColors(card));
 	const categoryLabels = $derived(getCategoryLabels(card));
 	const linkCount = $derived(card.hasChild ? 0 : card.link);
 	const subTypeLabel = $derived(getSubTypeLabel(card));
@@ -73,10 +72,10 @@
 	}}
 >
 	<div class="card-strip">
-		{#each stripColors as color}
+		{#each categoryLabels as cat}
 			<div
 				class="card-strip-segment"
-				style:background-color={color}
+				style:background-color={cat.color}
 			></div>
 		{/each}
 	</div>

--- a/packages/site/src/lib/Card.svelte
+++ b/packages/site/src/lib/Card.svelte
@@ -82,12 +82,14 @@
 	</div>
 
 	<div class="card-body">
-		{#each categoryLabels as cat}
-			<span
-				class="card-category"
-				style:color={cat.color}>{cat.label}</span
-			>
-		{/each}
+		<span class="card-categories">
+			{#each categoryLabels as cat}
+				<span
+					class="card-category"
+					style:color={cat.color}>{cat.label}</span
+				>
+			{/each}
+		</span>
 
 		<span
 			class="card-name"
@@ -190,10 +192,16 @@
 		min-width: 0;
 	}
 
+	.card-categories {
+		display: flex;
+		gap: 4px;
+		width: 36px;
+		flex-shrink: 0;
+	}
+
 	.card-category {
 		font-size: 9px;
 		font-weight: 700;
-		flex-shrink: 0;
 	}
 
 	.card-name {

--- a/packages/site/src/lib/Card.svelte
+++ b/packages/site/src/lib/Card.svelte
@@ -2,7 +2,7 @@
 	import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
 	import { Ban, Pin } from "lucide-svelte";
 	import { getCardState, toggleExclude, togglePin } from "$lib/stores/card-state.svelte";
-	import { getCategoryLabel, getStripColor, getSubTypeLabel } from "$lib/utils/card-display";
+	import { getCategoryLabels, getStripColors, getSubTypeLabel } from "$lib/utils/card-display";
 
 	type Props = {
 		/** Card data to render */
@@ -35,8 +35,8 @@
 	const isPinned = $derived(state === "pinned");
 	const isExcluded = $derived(state === "excluded");
 
-	const stripColor = $derived(getStripColor(card));
-	const categoryLabel = $derived(getCategoryLabel(card));
+	const stripColors = $derived(getStripColors(card));
+	const categoryLabels = $derived(getCategoryLabels(card));
 	const linkCount = $derived(card.hasChild ? 0 : card.link);
 	const subTypeLabel = $derived(getSubTypeLabel(card));
 
@@ -72,16 +72,22 @@
 		if (e.target === e.currentTarget && (e.key === "Enter" || e.key === " ")) handleCardClick();
 	}}
 >
-	<div
-		class="card-strip"
-		style:background-color={stripColor}
-	></div>
+	<div class="card-strip">
+		{#each stripColors as color}
+			<div
+				class="card-strip-segment"
+				style:background-color={color}
+			></div>
+		{/each}
+	</div>
 
 	<div class="card-body">
-		<span
-			class="card-category"
-			style:color={stripColor}>{categoryLabel}</span
-		>
+		{#each categoryLabels as cat}
+			<span
+				class="card-category"
+				style:color={cat.color}>{cat.label}</span
+			>
+		{/each}
 
 		<span
 			class="card-name"
@@ -167,6 +173,12 @@
 	.card-strip {
 		width: 4px;
 		flex-shrink: 0;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.card-strip-segment {
+		flex: 1;
 	}
 
 	.card-body {

--- a/packages/site/src/lib/Card.svelte
+++ b/packages/site/src/lib/Card.svelte
@@ -194,8 +194,8 @@
 
 	.card-categories {
 		display: flex;
-		gap: 4px;
-		width: 36px;
+		gap: 2px;
+		width: 40px;
 		flex-shrink: 0;
 	}
 

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -3,7 +3,7 @@
 	import { Coins, Layers, X } from "lucide-svelte";
 	import { onMount } from "svelte";
 	import { fade, fly } from "svelte/transition";
-	import { getCategoryLabel, getStripColor } from "$lib/utils/card-display";
+	import { getCategoryLabels, getStripColors } from "$lib/utils/card-display";
 
 	type Props = {
 		/** Card data to display in the detail sheet */
@@ -14,8 +14,8 @@
 
 	let { card, onClose }: Props = $props();
 
-	const stripColor = $derived(getStripColor(card));
-	const categoryLabel = $derived(getCategoryLabel(card));
+	const stripColors = $derived(getStripColors(card));
+	const categoryLabels = $derived(getCategoryLabels(card));
 
 	const effect = $derived(card.hasChild ? "" : card.effect);
 
@@ -66,10 +66,12 @@
 		<div class="detail-content">
 			<div class="detail-header">
 				<h2 class="detail-title">{card.name}</h2>
-				<span
-					class="detail-dot"
-					style:background-color={stripColor}
-				></span>
+				{#each stripColors as color}
+					<span
+						class="detail-dot"
+						style:background-color={color}
+					></span>
+				{/each}
 				<button
 					type="button"
 					class="detail-close"
@@ -82,12 +84,14 @@
 			</div>
 
 			<div class="detail-meta">
-				<span
-					class="detail-badge detail-badge--category"
-					style:background-color={stripColor}
-				>
-					{categoryLabel}
-				</span>
+				{#each categoryLabels as cat}
+					<span
+						class="detail-badge detail-badge--category"
+						style:background-color={cat.color}
+					>
+						{cat.label}
+					</span>
+				{/each}
 				<span class="detail-badge detail-badge--cost">
 					コスト {card.cost}
 				</span>

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -3,7 +3,7 @@
 	import { Coins, Layers, X } from "lucide-svelte";
 	import { onMount } from "svelte";
 	import { fade, fly } from "svelte/transition";
-	import { getCategoryLabels, getStripColors } from "$lib/utils/card-display";
+	import { getCategoryLabels } from "$lib/utils/card-display";
 
 	type Props = {
 		/** Card data to display in the detail sheet */
@@ -14,7 +14,6 @@
 
 	let { card, onClose }: Props = $props();
 
-	const stripColors = $derived(getStripColors(card));
 	const categoryLabels = $derived(getCategoryLabels(card));
 
 	const effect = $derived(card.hasChild ? "" : card.effect);
@@ -66,10 +65,10 @@
 		<div class="detail-content">
 			<div class="detail-header">
 				<h2 class="detail-title">{card.name}</h2>
-				{#each stripColors as color}
+				{#each categoryLabels as cat}
 					<span
 						class="detail-dot"
-						style:background-color={color}
+						style:background-color={cat.color}
 					></span>
 				{/each}
 				<button

--- a/packages/site/src/lib/ExcludeList.svelte
+++ b/packages/site/src/lib/ExcludeList.svelte
@@ -147,6 +147,7 @@
 		align-self: stretch;
 		display: flex;
 		flex-direction: column;
+		overflow: hidden;
 	}
 
 	.exclude-strip-segment {

--- a/packages/site/src/lib/ExcludeList.svelte
+++ b/packages/site/src/lib/ExcludeList.svelte
@@ -2,7 +2,7 @@
 	import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
 	import { Ban, ChevronDown, ChevronUp, X } from "lucide-svelte";
 	import { toggleExclude } from "$lib/stores/card-state.svelte";
-	import { getCategoryLabel, getStripColor } from "$lib/utils/card-display";
+	import { getCategoryLabels, getStripColors } from "$lib/utils/card-display";
 
 	type Props = {
 		/** Cards currently excluded from the draw pool */
@@ -51,14 +51,20 @@
 					<div class="exclude-divider"></div>
 				{/if}
 				<div class="exclude-row">
-					<div
-						class="exclude-strip"
-						style:background-color={getStripColor(card)}
-					></div>
-					<span
-						class="exclude-category"
-						style:color={getStripColor(card)}>{getCategoryLabel(card)}</span
-					>
+					<div class="exclude-strip">
+						{#each getStripColors(card) as color}
+							<div
+								class="exclude-strip-segment"
+								style:background-color={color}
+							></div>
+						{/each}
+					</div>
+					{#each getCategoryLabels(card) as cat}
+						<span
+							class="exclude-category"
+							style:color={cat.color}>{cat.label}</span
+						>
+					{/each}
 					<span class="exclude-card-name">{card.name}</span>
 					<span class="exclude-cost">{card.cost}</span>
 					<button
@@ -138,6 +144,12 @@
 		width: 3px;
 		border-radius: 2px;
 		align-self: stretch;
+		display: flex;
+		flex-direction: column;
+	}
+
+	.exclude-strip-segment {
+		flex: 1;
 	}
 
 	.exclude-category {

--- a/packages/site/src/lib/ExcludeList.svelte
+++ b/packages/site/src/lib/ExcludeList.svelte
@@ -2,7 +2,7 @@
 	import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
 	import { Ban, ChevronDown, ChevronUp, X } from "lucide-svelte";
 	import { toggleExclude } from "$lib/stores/card-state.svelte";
-	import { getCategoryLabels, getStripColors } from "$lib/utils/card-display";
+	import { getCategoryLabels } from "$lib/utils/card-display";
 
 	type Props = {
 		/** Cards currently excluded from the draw pool */
@@ -50,16 +50,17 @@
 				{#if i > 0}
 					<div class="exclude-divider"></div>
 				{/if}
+				{@const categories = getCategoryLabels(card)}
 				<div class="exclude-row">
 					<div class="exclude-strip">
-						{#each getStripColors(card) as color}
+						{#each categories as cat}
 							<div
 								class="exclude-strip-segment"
-								style:background-color={color}
+								style:background-color={cat.color}
 							></div>
 						{/each}
 					</div>
-					{#each getCategoryLabels(card) as cat}
+					{#each categories as cat}
 						<span
 							class="exclude-category"
 							style:color={cat.color}>{cat.label}</span

--- a/packages/site/src/lib/utils/card-display.ts
+++ b/packages/site/src/lib/utils/card-display.ts
@@ -36,11 +36,6 @@ const mainTypeColors: Record<MainType, string> = {
   princess: "var(--card-princess)",
 };
 
-export function getStripColors(card: CommonCard): string[] {
-  const types = getMainTypes(card);
-  return types.map((t) => mainTypeColors[t]);
-}
-
 export function getCategoryLabels(
   card: CommonCard,
 ): { label: string; color: string }[] {

--- a/packages/site/src/lib/utils/card-display.ts
+++ b/packages/site/src/lib/utils/card-display.ts
@@ -28,12 +28,12 @@ export function getMainTypes(card: CommonCard): MainType[] {
 }
 
 const mainTypeColors: Record<MainType, string> = {
-  action: "var(--accent-indigo)",
-  attack: "var(--accent-red)",
-  territory: "var(--accent-green)",
-  succession: "var(--accent-silver)",
-  disaster: "var(--accent-coral)",
-  princess: "var(--accent-pink)",
+  action: "var(--card-action)",
+  attack: "var(--card-attack)",
+  territory: "var(--card-territory)",
+  succession: "var(--card-succession)",
+  disaster: "var(--card-disaster)",
+  princess: "var(--card-princess)",
 };
 
 export function getStripColors(card: CommonCard): string[] {

--- a/packages/site/src/lib/utils/card-display.ts
+++ b/packages/site/src/lib/utils/card-display.ts
@@ -27,20 +27,28 @@ export function getMainTypes(card: CommonCard): MainType[] {
     : card.mainType;
 }
 
-export function getStripColor(card: CommonCard): string {
+const mainTypeColors: Record<MainType, string> = {
+  action: "var(--accent-indigo)",
+  attack: "var(--accent-red)",
+  territory: "var(--accent-green)",
+  succession: "var(--accent-silver)",
+  disaster: "var(--accent-coral)",
+  princess: "var(--accent-pink)",
+};
+
+export function getStripColors(card: CommonCard): string[] {
   const types = getMainTypes(card);
-  if (types.includes("attack")) {
-    return "var(--accent-red)";
-  }
-  if (types.includes("territory")) {
-    return "var(--accent-green)";
-  }
-  return "var(--accent-indigo)";
+  return types.map((t) => mainTypeColors[t]);
 }
 
-export function getCategoryLabel(card: CommonCard): string {
+export function getCategoryLabels(
+  card: CommonCard,
+): { label: string; color: string }[] {
   const types = getMainTypes(card);
-  return mainTypeLabels[types[0]];
+  return types.map((t) => ({
+    label: mainTypeLabels[t],
+    color: mainTypeColors[t],
+  }));
 }
 
 export function getSubTypeLabel(card: CommonCard): string | undefined {


### PR DESCRIPTION
## Summary

Cards with multiple MainTypes now display each type's color individually, using a vertically split strip and separate category badges.

## Details

Previously, cards with multiple MainTypes (e.g. action + attack) were assigned a single color based on a priority system (attack > territory > default indigo). This made it impossible to visually distinguish which types a card had at a glance, especially for combinations like action + succession which both mapped to indigo.

This change assigns a unique color to each MainType and updates the strip and badge rendering to show all types. The color mapping is: attack (red), territory (brown), action (indigo), succession (green), disaster (coral), princess (pink).

## Confirmation

- Verify single-type cards still display one color strip and one badge
- Verify multi-type cards (e.g. 破城槌, 辺境伯) show a split strip and two badges
- Check the exclude list renders correctly for multi-type excluded cards
- Check the card detail modal shows multiple dots and badges

## Limitation

No known limitations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cards, card details, and exclude lists now show multiple stacked color segments and multiple category labels/badges so all applicable categories are displayed.

* **Style**
  * Added six global theme colors for cards: --card-action, --card-attack, --card-disaster, --card-princess, --card-succession, --card-territory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->