### PR TITLE
chore(biome): delegate excludes to .gitignore via vcs config

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -7,15 +7,7 @@
     "useIgnoreFile": true
   },
   "files": {
-    "includes": [
-      "**",
-      "!**/node_modules",
-      "!**/dist",
-      "!**/package.json",
-      "!**/.svelte-kit/**",
-      "!**/playwright-report/**",
-      "!**/test-results/**"
-    ]
+    "includes": ["**", "!**/package.json"]
   },
   "formatter": {
     "enabled": true,

--- a/biome.json
+++ b/biome.json
@@ -1,6 +1,11 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.4.15/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "on" } } },
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
   "files": {
     "includes": [
       "**",


### PR DESCRIPTION
## Summary

Configure Biome to honor `.gitignore` through its `vcs` setting and remove redundant `files.includes` patterns that are already ignored by git.

## Details

Previously `biome.json` listed several directories (`node_modules`, `dist`, `.svelte-kit`, `playwright-report`, `test-results`) as explicit excludes, all of which are also tracked in `.gitignore`. Maintaining the same exclusion list in two places risks drift whenever a new build artifact directory is added.

Biome supports reading `.gitignore` directly via `vcs.useIgnoreFile`, so the two-step change here first opts into that behavior, then drops the now-duplicated entries. Only `!**/package.json` remains under `files.includes` because it is not ignored by git but should still be skipped by Biome.

## Confirmation

- `pnpm check:biome` (or `pnpm check`) succeeds and inspects the same set of files as before.
- Files in ignored directories (e.g. `node_modules`, `dist`, `.svelte-kit`) are still excluded from Biome's reports.
- `package.json` files continue to be skipped by Biome.

## Limitation

No known limitations.