### PR TITLE
ci: gate auto-merge on cancelled CI jobs

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -75,12 +75,13 @@ jobs:
       - run: pnpm --filter=@heart-of-crown-randomizer/site exec playwright install
       - run: pnpm --filter ./packages/site run test:e2e
   status-check:
-    timeout-minutes: 30
+    timeout-minutes: 1
     runs-on: ubuntu-latest
     needs:
       - nix-flake-check
       - check-typescript
     permissions: {}
-    if: failure()
+    if: ${{ always() }}
     steps:
-      - run: exit 1
+      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+        run: exit 1

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -83,5 +83,5 @@ jobs:
     permissions: {}
     if: ${{ always() }}
     steps:
-      - if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}
+      - if: ${{ always() && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
         run: exit 1


### PR DESCRIPTION
## Summary

Prevent PRs from being auto-merged when a required CI job is cancelled (e.g. by timeout).

## Details

The `status-check` job in `.github/workflows/push.yaml` is registered as a required status check in the repository ruleset, so it acts as the single gate for all CI jobs. Its previous `if: failure()` condition only fires on outright failures. When an upstream job was cancelled (such as `check-typescript (current)` hitting its 30-minute timeout), `failure()` evaluated to false and `status-check` ended up SKIPPED. Rulesets treat a SKIPPED required check as passing, so PRs were being auto-merged despite cancelled CI. This was observed on #1770 where `check-typescript (current)` was CANCELLED and `status-check` was SKIPPED, yet the merge proceeded.

Switching to `if: always()` plus a step-level `contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')` makes the gate run unconditionally and report FAILURE whenever any upstream job failed or was cancelled. Jobs skipped via path filters (e.g. `check-typescript` skipped when no TypeScript files changed) keep reporting SUCCESS at the gate, preserving existing behavior for unrelated diffs.

The job timeout is reduced from 30 to 1 minute since the gate only waits on dependencies.

## Confirmation

- This PR's CI: `status-check` reports SUCCESS (all upstream jobs pass).
- Future PR with a cancelled or failed upstream job: `status-check` reports FAILURE and blocks auto-merge.
- PR touching only non-TypeScript files (path filter skips `check-typescript`): `status-check` still reports SUCCESS.

## Limitation

Only the success path is directly verifiable on this PR. The cancel-blocks-merge behavior will be observable on the next PR that incurs a cancelled upstream job.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration workflow timeout configuration for faster failure detection.
  * Enhanced status check logic to more reliably identify job failures and cancellations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Omochice/heart-of-crown-randomizer/pull/1773)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->