### PR TITLE
fix: respect constraints and exclusions on additional draw

### DIFF
--- a/packages/site/src/lib/utils/card-draw.test.ts
+++ b/packages/site/src/lib/utils/card-draw.test.ts
@@ -174,6 +174,24 @@ describe("drawMissingCommons with constraints", () => {
     expect(result).toHaveLength(1);
     expect(noAttack.isSatisfied([...selected, ...result])).toBe(true);
   });
+
+  it("does not fill with cards the user excluded", () => {
+    const selected = allCommons.slice(0, 7);
+    const excludedIds = new Set([8, 9, 10]);
+
+    const result = drawMissingCommons(
+      allCommons,
+      selected,
+      10,
+      [],
+      excludedIds,
+    );
+
+    const resultIds = result.map((c) => c.id);
+    for (const excludedId of excludedIds) {
+      expect(resultIds).not.toContain(excludedId);
+    }
+  });
 });
 
 describe("buildCardUrl", () => {

--- a/packages/site/src/lib/utils/card-draw.test.ts
+++ b/packages/site/src/lib/utils/card-draw.test.ts
@@ -1,6 +1,8 @@
-import type {
-  Constraint,
-  SelectionContext,
+import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+import {
+  type Constraint,
+  noAttack,
+  type SelectionContext,
 } from "@heart-of-crown-randomizer/constraint";
 import { decodeIds } from "@heart-of-crown-randomizer/id-codec";
 import { describe, expect, it } from "vitest";
@@ -150,6 +152,27 @@ describe("drawMissingCommons", () => {
     const result = drawMissingCommons(allCommons, allCommons, 25);
 
     expect(result).toHaveLength(0);
+  });
+});
+
+describe("drawMissingCommons with constraints", () => {
+  const makeAttackCard = (id: number): CommonCard => ({
+    ...makeCard(id),
+    mainType: ["attack"],
+  });
+
+  it("adds no attack card when noAttack is active and only attack cards remain to fill the slot", () => {
+    const selected = Array.from({ length: 9 }, (_, i) => makeCard(i + 1));
+    const pool = [
+      ...selected,
+      ...Array.from({ length: 6 }, (_, i) => makeAttackCard(i + 10)),
+    ];
+
+    const result = drawMissingCommons(pool, selected, 10, [noAttack]);
+
+    for (const card of result) {
+      expect(card.mainType).not.toContain("attack");
+    }
   });
 });
 

--- a/packages/site/src/lib/utils/card-draw.test.ts
+++ b/packages/site/src/lib/utils/card-draw.test.ts
@@ -1,4 +1,4 @@
-import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+import type { DuplicateCard } from "@heart-of-crown-randomizer/card/type";
 import {
   type Constraint,
   noAttack,
@@ -156,23 +156,23 @@ describe("drawMissingCommons", () => {
 });
 
 describe("drawMissingCommons with constraints", () => {
-  const makeAttackCard = (id: number): CommonCard => ({
-    ...makeCard(id),
+  const makeAttackCard = (id: number): DuplicateCard => ({
+    ...(makeCard(id) as DuplicateCard),
     mainType: ["attack"],
   });
 
-  it("adds no attack card when noAttack is active and only attack cards remain to fill the slot", () => {
+  it("does not fill with attack cards when noAttack is active and non-attack cards are available", () => {
     const selected = Array.from({ length: 9 }, (_, i) => makeCard(i + 1));
     const pool = [
       ...selected,
-      ...Array.from({ length: 6 }, (_, i) => makeAttackCard(i + 10)),
+      ...Array.from({ length: 3 }, (_, i) => makeCard(i + 10)),
+      ...Array.from({ length: 6 }, (_, i) => makeAttackCard(i + 13)),
     ];
 
     const result = drawMissingCommons(pool, selected, 10, [noAttack]);
 
-    for (const card of result) {
-      expect(card.mainType).not.toContain("attack");
-    }
+    expect(result).toHaveLength(1);
+    expect(noAttack.isSatisfied([...selected, ...result])).toBe(true);
   });
 });
 

--- a/packages/site/src/lib/utils/card-draw.ts
+++ b/packages/site/src/lib/utils/card-draw.ts
@@ -64,13 +64,16 @@ export function drawMissingCommons(
   selectedCommons: CommonCard[],
   numberOfCommons: number,
   constraints?: readonly Constraint[],
+  excludedIds?: ReadonlySet<number>,
 ): CommonCard[] {
   if (selectedCommons.length >= numberOfCommons) {
     return [];
   }
 
   const selectedIds = new Set(selectedCommons.map((c) => c.id));
-  const hasAvailable = allCommons.some((c) => !selectedIds.has(c.id));
+  const hasAvailable = allCommons.some(
+    (c) => !selectedIds.has(c.id) && !excludedIds?.has(c.id),
+  );
   if (!hasAvailable) {
     return [];
   }
@@ -78,7 +81,7 @@ export function drawMissingCommons(
   const filled = selectWithConstraints(
     allCommons,
     selectedCommons,
-    new Set(),
+    excludedIds ?? new Set(),
     numberOfCommons,
     constraints,
   );

--- a/packages/site/src/lib/utils/card-draw.ts
+++ b/packages/site/src/lib/utils/card-draw.ts
@@ -1,7 +1,6 @@
 import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
 import type { Constraint } from "@heart-of-crown-randomizer/constraint";
 import { encodeIds } from "@heart-of-crown-randomizer/id-codec";
-import { filterByIds, select } from "@heart-of-crown-randomizer/randomizer";
 import { selectWithConstraints } from "./select-with-constraints";
 import {
   validateExcludeConstraints,
@@ -55,27 +54,35 @@ export function drawRandomCards(
 }
 
 /**
- * We filter out already-selected cards by ID rather than by reference
- * because card objects may differ between renders while IDs are stable.
+ * The already-selected cards are passed as required so the same
+ * constraint-aware selection used by the initial draw fills the
+ * remaining slots; otherwise an additional draw could add cards that
+ * an active constraint excludes (e.g. attack cards under noAttack).
  */
 export function drawMissingCommons(
   allCommons: CommonCard[],
   selectedCommons: CommonCard[],
   numberOfCommons: number,
+  constraints?: readonly Constraint[],
 ): CommonCard[] {
   if (selectedCommons.length >= numberOfCommons) {
     return [];
   }
 
-  const excludedIds = selectedCommons.map((c) => c.id);
-  const availableCommons = filterByIds(allCommons, excludedIds);
-
-  if (availableCommons.length === 0) {
+  const selectedIds = new Set(selectedCommons.map((c) => c.id));
+  const hasAvailable = allCommons.some((c) => !selectedIds.has(c.id));
+  if (!hasAvailable) {
     return [];
   }
 
-  const cardsToAdd = numberOfCommons - selectedCommons.length;
-  return select(availableCommons, cardsToAdd);
+  const filled = selectWithConstraints(
+    allCommons,
+    selectedCommons,
+    new Set(),
+    numberOfCommons,
+    constraints,
+  );
+  return filled.filter((c) => !selectedIds.has(c.id));
 }
 
 /**

--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -146,11 +146,13 @@
 
 	function drawMissingCommons() {
 		const activeConstraints = getEnabledConstraints(allConstraints);
+		const excludedIds = getExcludedCardIds();
 		const newCards = drawMissingCommonsLogic(
 			allCommons,
 			selectedCommons,
 			numberOfCommons,
 			activeConstraints,
+			excludedIds,
 		);
 		if (newCards.length === 0) {
 			return;

--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -145,7 +145,13 @@
 		});
 
 	function drawMissingCommons() {
-		const newCards = drawMissingCommonsLogic(allCommons, selectedCommons, numberOfCommons);
+		const activeConstraints = getEnabledConstraints(allConstraints);
+		const newCards = drawMissingCommonsLogic(
+			allCommons,
+			selectedCommons,
+			numberOfCommons,
+			activeConstraints,
+		);
 		if (newCards.length === 0) {
 			return;
 		}


### PR DESCRIPTION
drawMissingCommons ignores active constraints when refilling removed
slots, so an additional draw can add cards a constraint excludes (for
example an attack card while noAttack is active). Pin this expected
behavior so the upcoming fix is verified.

close #1898

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test suite validating constraint-aware card drawing, including attack-type restrictions and excluded card handling.

* **Improvements**
  * Card drawing now respects active constraints and excluded card IDs when filling missing common cards, providing more controlled randomization during deck building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->