### PR TITLE
feat: close card detail with a downward swipe

### DIFF
--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -43,10 +43,17 @@
 		};
 	});
 
-	// A click whose target is the dialog itself landed on the (transparent)
-	// native backdrop rather than the sheet content, so treat it as dismiss.
+	// A modal dialog reports backdrop clicks as clicks on the dialog itself, but
+	// so are clicks on the dialog's own padding gutter. Comparing against the
+	// sheet's bounds dismisses only when the click truly landed outside it.
 	function handleDialogClick(event: MouseEvent) {
-		if (event.target === dialogRef) {
+		const rect = dialogRef.getBoundingClientRect();
+		const isOutsideSheet =
+			event.clientX < rect.left ||
+			event.clientX > rect.right ||
+			event.clientY < rect.top ||
+			event.clientY > rect.bottom;
+		if (isOutsideSheet) {
 			onClose();
 		}
 	}

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -4,6 +4,7 @@
 	import { onMount } from "svelte";
 	import { fade, fly } from "svelte/transition";
 	import { getCategoryLabels } from "$lib/utils/card-display";
+	import { swipeDownToDismiss } from "$lib/utils/swipe-down-to-dismiss";
 
 	type Props = {
 		/** Card data to display in the detail sheet */
@@ -59,6 +60,7 @@
 		aria-label="カード詳細: {card.name}"
 		transition:fly={{ y: 400, duration: 300 }}
 		onclick={(e) => e.stopPropagation()}
+		use:swipeDownToDismiss={{ onDismiss: onClose }}
 	>
 		<div class="detail-handle"></div>
 

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -27,13 +27,9 @@
 
 	let dialogRef: HTMLDialogElement;
 
-	// `showModal` is what makes the background inert and the dialog top-layer;
-	// the `open` attribute alone would not. Focus moves to the close button (the
-	// only focusable descendant) automatically, so no manual focus is needed.
-	//
-	// `showModal` does not lock page scrolling, so the page behind would still
-	// scroll; locking the body keeps the gesture contained to the sheet until
-	// the sheet is dismissed.
+	// showModal (not the `open` attribute) makes the background inert and
+	// top-layer and moves focus to the close button. It does not lock page
+	// scrolling, so the body is locked here to keep the gesture on the sheet.
 	onMount(() => {
 		dialogRef.showModal();
 		const previousOverflow = document.body.style.overflow;
@@ -43,11 +39,9 @@
 		};
 	});
 
-	// A genuine backdrop click targets the dialog element itself and lands
-	// outside the sheet. Requiring the target rules out clicks bubbling up from
-	// children (whose keyboard/programmatic events carry clientX/Y 0 and would
-	// otherwise read as outside), while the bounds check rules out the dialog's
-	// own padding gutter, which also targets the dialog but sits inside it.
+	// A real backdrop click targets the dialog itself and lands outside its
+	// bounds. The target check ignores bubbled child clicks (whose synthetic
+	// events carry clientX/Y 0); the bounds check ignores the padding gutter.
 	function handleDialogClick(event: MouseEvent) {
 		if (event.target !== dialogRef) {
 			return;
@@ -63,8 +57,7 @@
 		}
 	}
 
-	// Let Svelte's exit transition drive the close instead of the dialog closing
-	// itself instantly, so the sheet animates out on Escape like every other path.
+	// Drive the close through Svelte's exit transition so Escape animates out too.
 	function handleCancel(event: Event) {
 		event.preventDefault();
 		onClose();
@@ -166,20 +159,14 @@
 </dialog>
 
 <style>
-	/*
-	 * Visual dim only. The dialog's own ::backdrop is kept transparent and used
-	 * solely for modal hit-testing, so this element can fade in and out with the
-	 * sheet via a Svelte transition, which ::backdrop cannot do on exit.
-	 */
+	/* Visual dim only; the native ::backdrop stays transparent for hit-testing.
+	   A separate element lets the dim fade out with the sheet, which ::backdrop
+	   cannot. z-index outranks the other page layers (app menu is 100) so the
+	   normal-flow dim covers the whole background while the sheet is top-layer. */
 	.detail-backdrop {
 		position: fixed;
 		inset: 0;
 		background: rgba(0, 0, 0, 0.4);
-		/*
-		 * The sheet is in the top layer, but this dim is a normal-flow element,
-		 * so it must outrank every other page layer (the app menu is z-index 100)
-		 * to keep the whole background dimmed behind the modal.
-		 */
 		z-index: 200;
 	}
 

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -25,143 +25,165 @@
 
 	const coin = $derived(card.hasChild ? undefined : card.coin);
 
-	let closeButtonRef: HTMLButtonElement;
+	let dialogRef: HTMLDialogElement;
 
+	// `showModal` is what makes the background inert and the dialog top-layer;
+	// the `open` attribute alone would not. Focus moves to the close button (the
+	// only focusable descendant) automatically, so no manual focus is needed.
+	//
+	// `showModal` does not lock page scrolling, so the page behind would still
+	// scroll; locking the body keeps the gesture contained to the sheet until
+	// the sheet is dismissed.
 	onMount(() => {
-		closeButtonRef?.focus();
+		dialogRef.showModal();
+		const previousOverflow = document.body.style.overflow;
+		document.body.style.overflow = "hidden";
+		return () => {
+			document.body.style.overflow = previousOverflow;
+		};
 	});
 
-	function handleBackdropClick() {
-		onClose();
-	}
-
-	function handleKeydown(e: KeyboardEvent) {
-		if (e.key === "Escape") {
+	// A click whose target is the dialog itself landed on the (transparent)
+	// native backdrop rather than the sheet content, so treat it as dismiss.
+	function handleDialogClick(event: MouseEvent) {
+		if (event.target === dialogRef) {
 			onClose();
 		}
 	}
+
+	// Let Svelte's exit transition drive the close instead of the dialog closing
+	// itself instantly, so the sheet animates out on Escape like every other path.
+	function handleCancel(event: Event) {
+		event.preventDefault();
+		onClose();
+	}
 </script>
 
-<svelte:window onkeydown={handleKeydown} />
-
-<!-- svelte-ignore a11y_no_static_element_interactions -->
 <div
 	class="detail-backdrop"
 	transition:fade={{ duration: 200 }}
-	onclick={handleBackdropClick}
-	onkeydown={handleKeydown}
+	aria-hidden="true"
+></div>
+
+<dialog
+	bind:this={dialogRef}
+	class="detail-sheet"
+	aria-label="カード詳細: {card.name}"
+	transition:fly={{ y: 400, duration: 300 }}
+	onclick={handleDialogClick}
+	oncancel={handleCancel}
+	use:swipeDownToDismiss={{ onDismiss: onClose }}
 >
-	<!-- svelte-ignore a11y_click_events_have_key_events -->
-	<div
-		class="detail-sheet"
-		role="dialog"
-		aria-modal="true"
-		tabindex="-1"
-		aria-label="カード詳細: {card.name}"
-		transition:fly={{ y: 400, duration: 300 }}
-		onclick={(e) => e.stopPropagation()}
-		use:swipeDownToDismiss={{ onDismiss: onClose }}
-	>
-		<div class="detail-handle"></div>
+	<div class="detail-handle"></div>
 
-		<div class="detail-content">
-			<div class="detail-header">
-				<h2 class="detail-title">{card.name}</h2>
-				{#each categoryLabels as cat}
-					<span
-						class="detail-dot"
-						style:background-color={cat.color}
-					></span>
-				{/each}
-				<button
-					type="button"
-					class="detail-close"
-					bind:this={closeButtonRef}
-					onclick={onClose}
-					aria-label="閉じる"
+	<div class="detail-content">
+		<div class="detail-header">
+			<h2 class="detail-title">{card.name}</h2>
+			{#each categoryLabels as cat}
+				<span
+					class="detail-dot"
+					style:background-color={cat.color}
+				></span>
+			{/each}
+			<button
+				type="button"
+				class="detail-close"
+				onclick={onClose}
+				aria-label="閉じる"
+			>
+				<X size={16} />
+			</button>
+		</div>
+
+		<div class="detail-meta">
+			{#each categoryLabels as cat}
+				<span
+					class="detail-badge detail-badge--category"
+					style:background-color={cat.color}
 				>
-					<X size={16} />
-				</button>
-			</div>
-
-			<div class="detail-meta">
-				{#each categoryLabels as cat}
-					<span
-						class="detail-badge detail-badge--category"
-						style:background-color={cat.color}
-					>
-						{cat.label}
-					</span>
-				{/each}
-				<span class="detail-badge detail-badge--cost">
-					コスト {card.cost}
+					{cat.label}
 				</span>
-				{#if linkCount > 0}
-					<span class="detail-badge detail-badge--link">
-						<Layers size={12} />
-						リンク {linkCount}
-					</span>
-				{/if}
-			</div>
-
-			{#if succession !== undefined}
-				<div class="detail-info-row">
-					<span class="detail-info-label">継承点</span>
-					<span class="detail-info-value">{succession}</span>
-				</div>
-			{/if}
-
-			{#if coin !== undefined}
-				<div class="detail-info-row">
-					<Coins size={14} />
-					<span class="detail-info-label">コイン</span>
-					<span class="detail-info-value">{coin}</span>
-				</div>
-			{/if}
-
-			<div class="detail-divider"></div>
-
-			{#if effect}
-				<div class="detail-section">
-					<h3 class="detail-section-label">カード説明</h3>
-					<p class="detail-effect">{effect}</p>
-				</div>
-			{/if}
-
-			{#if card.hasChild && card.cards.length > 1}
-				<div class="detail-section">
-					<h3 class="detail-section-label">バリエーション</h3>
-					{#each card.cards as variant, i (i)}
-						<div class="detail-variant">
-							<span class="detail-variant-name">{variant.name}</span>
-							<span class="detail-variant-effect">{variant.effect}</span>
-						</div>
-					{/each}
-				</div>
+			{/each}
+			<span class="detail-badge detail-badge--cost">
+				コスト {card.cost}
+			</span>
+			{#if linkCount > 0}
+				<span class="detail-badge detail-badge--link">
+					<Layers size={12} />
+					リンク {linkCount}
+				</span>
 			{/if}
 		</div>
+
+		{#if succession !== undefined}
+			<div class="detail-info-row">
+				<span class="detail-info-label">継承点</span>
+				<span class="detail-info-value">{succession}</span>
+			</div>
+		{/if}
+
+		{#if coin !== undefined}
+			<div class="detail-info-row">
+				<Coins size={14} />
+				<span class="detail-info-label">コイン</span>
+				<span class="detail-info-value">{coin}</span>
+			</div>
+		{/if}
+
+		<div class="detail-divider"></div>
+
+		{#if effect}
+			<div class="detail-section">
+				<h3 class="detail-section-label">カード説明</h3>
+				<p class="detail-effect">{effect}</p>
+			</div>
+		{/if}
+
+		{#if card.hasChild && card.cards.length > 1}
+			<div class="detail-section">
+				<h3 class="detail-section-label">バリエーション</h3>
+				{#each card.cards as variant, i (i)}
+					<div class="detail-variant">
+						<span class="detail-variant-name">{variant.name}</span>
+						<span class="detail-variant-effect">{variant.effect}</span>
+					</div>
+				{/each}
+			</div>
+		{/if}
 	</div>
-</div>
+</dialog>
 
 <style>
+	/*
+	 * Visual dim only. The dialog's own ::backdrop is kept transparent and used
+	 * solely for modal hit-testing, so this element can fade in and out with the
+	 * sheet via a Svelte transition, which ::backdrop cannot do on exit.
+	 */
 	.detail-backdrop {
 		position: fixed;
 		inset: 0;
 		background: rgba(0, 0, 0, 0.4);
 		z-index: 50;
-		display: flex;
-		align-items: flex-end;
-		justify-content: center;
 	}
 
 	.detail-sheet {
+		position: fixed;
+		inset: auto 0 0 0;
+		margin: 0 auto;
 		background: var(--bg-primary);
+		border: none;
 		border-radius: 24px 24px 0 0;
 		width: 100%;
 		max-width: 48rem;
 		max-height: 80vh;
 		overflow-y: auto;
+		/* Stop a swipe or scroll at the sheet edge from chaining to the page. */
+		overscroll-behavior: contain;
 		padding-top: 12px;
+	}
+
+	.detail-sheet::backdrop {
+		background: transparent;
 	}
 
 	.detail-handle {

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -43,10 +43,15 @@
 		};
 	});
 
-	// A modal dialog reports backdrop clicks as clicks on the dialog itself, but
-	// so are clicks on the dialog's own padding gutter. Comparing against the
-	// sheet's bounds dismisses only when the click truly landed outside it.
+	// A genuine backdrop click targets the dialog element itself and lands
+	// outside the sheet. Requiring the target rules out clicks bubbling up from
+	// children (whose keyboard/programmatic events carry clientX/Y 0 and would
+	// otherwise read as outside), while the bounds check rules out the dialog's
+	// own padding gutter, which also targets the dialog but sits inside it.
 	function handleDialogClick(event: MouseEvent) {
+		if (event.target !== dialogRef) {
+			return;
+		}
 		const rect = dialogRef.getBoundingClientRect();
 		const isOutsideSheet =
 			event.clientX < rect.left ||

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -179,7 +179,8 @@
 		overflow-y: auto;
 		/* Stop a swipe or scroll at the sheet edge from chaining to the page. */
 		overscroll-behavior: contain;
-		padding-top: 12px;
+		/* Reset the UA dialog padding; only the top gap is wanted here. */
+		padding: 12px 0 0;
 	}
 
 	.detail-sheet::backdrop {

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -27,9 +27,9 @@
 
 	let dialogRef: HTMLDialogElement;
 
-	// showModal (not the `open` attribute) makes the background inert and
-	// top-layer and moves focus to the close button. It does not lock page
-	// scrolling, so the body is locked here to keep the gesture on the sheet.
+	// The `open` attribute would show the dialog but not make it modal, inert, or
+	// focus-trapping; showModal does, but still does not lock page scroll, so the
+	// body is locked here too.
 	onMount(() => {
 		dialogRef.showModal();
 		const previousOverflow = document.body.style.overflow;
@@ -39,9 +39,9 @@
 		};
 	});
 
-	// A real backdrop click targets the dialog itself and lands outside its
-	// bounds. The target check ignores bubbled child clicks (whose synthetic
-	// events carry clientX/Y 0); the bounds check ignores the padding gutter.
+	// Target-only would also fire on the padding gutter; bounds-only would fire on
+	// bubbled child clicks (whose synthetic events carry clientX/Y 0). Both
+	// together leave only genuine backdrop clicks.
 	function handleDialogClick(event: MouseEvent) {
 		if (event.target !== dialogRef) {
 			return;
@@ -57,7 +57,8 @@
 		}
 	}
 
-	// Drive the close through Svelte's exit transition so Escape animates out too.
+	// preventDefault stops the dialog's instant native close so Escape animates
+	// out via Svelte like every other dismissal path.
 	function handleCancel(event: Event) {
 		event.preventDefault();
 		onClose();
@@ -159,10 +160,10 @@
 </dialog>
 
 <style>
-	/* Visual dim only; the native ::backdrop stays transparent for hit-testing.
-	   A separate element lets the dim fade out with the sheet, which ::backdrop
-	   cannot. z-index outranks the other page layers (app menu is 100) so the
-	   normal-flow dim covers the whole background while the sheet is top-layer. */
+	/* Not the native ::backdrop: it cannot fade out on exit, so a separate element
+	   carries the dim (::backdrop stays transparent, used only for hit-testing).
+	   z-index must outrank the other page layers (app menu is 100) because this
+	   dim is normal-flow while the sheet is top-layer. */
 	.detail-backdrop {
 		position: fixed;
 		inset: 0;
@@ -181,9 +182,9 @@
 		max-width: 48rem;
 		max-height: 80vh;
 		overflow-y: auto;
-		/* Stop a swipe or scroll at the sheet edge from chaining to the page. */
+		/* Without contain, a swipe or scroll at the sheet edge chains to the page. */
 		overscroll-behavior: contain;
-		/* Reset the UA dialog padding; only the top gap is wanted here. */
+		/* The UA dialog padding (1em) would pad all sides; keep only the top gap. */
 		padding: 12px 0 0;
 	}
 

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -175,7 +175,12 @@
 		position: fixed;
 		inset: 0;
 		background: rgba(0, 0, 0, 0.4);
-		z-index: 50;
+		/*
+		 * The sheet is in the top layer, but this dim is a normal-flow element,
+		 * so it must outrank every other page layer (the app menu is z-index 100)
+		 * to keep the whole background dimmed behind the modal.
+		 */
+		z-index: 200;
 	}
 
 	.detail-sheet {

--- a/packages/site/src/lib/CardDetail.svelte.test.ts
+++ b/packages/site/src/lib/CardDetail.svelte.test.ts
@@ -1,0 +1,103 @@
+import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+import { fireEvent, render, screen } from "@testing-library/svelte";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import CardDetail from "./CardDetail.svelte";
+
+const mockCard: CommonCard = {
+  id: 1,
+  name: "Test Card",
+  cost: 3,
+  type: "common",
+  link: 0,
+  mainType: ["attack"],
+  effect: "",
+  hasChild: false,
+  edition: 0,
+};
+
+const sheetRect = {
+  left: 100,
+  top: 100,
+  right: 300,
+  bottom: 500,
+  width: 200,
+  height: 400,
+  x: 100,
+  y: 100,
+  toJSON: () => ({}),
+} satisfies DOMRect;
+
+function renderSheet(onClose: () => void): HTMLDialogElement {
+  const { container } = render(CardDetail, {
+    props: { card: mockCard, onClose },
+  });
+  const dialog = container.querySelector("dialog");
+  if (dialog === null) {
+    throw new Error("dialog was not rendered");
+  }
+  // jsdom does not lay elements out, so pin a known rect for the bounds check.
+  dialog.getBoundingClientRect = () => sheetRect;
+  return dialog;
+}
+
+describe("CardDetail backdrop dismissal", () => {
+  const originalShowModal = HTMLDialogElement.prototype.showModal;
+  const originalClose = HTMLDialogElement.prototype.close;
+  const originalAnimate = Element.prototype.animate;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // jsdom does not implement modal dialogs; emulate just the open state the
+    // component relies on so onMount does not throw.
+    HTMLDialogElement.prototype.showModal = function showModal() {
+      this.open = true;
+    };
+    HTMLDialogElement.prototype.close = function close() {
+      this.open = false;
+    };
+    // jsdom lacks the Web Animations API that Svelte's fly/fade transitions use.
+    Element.prototype.animate = () =>
+      ({
+        cancel() {},
+        pause() {},
+        play() {},
+        finished: Promise.resolve(),
+        onfinish: null,
+        currentTime: 0,
+        startTime: 0,
+      }) as unknown as Animation;
+  });
+
+  afterEach(() => {
+    HTMLDialogElement.prototype.showModal = originalShowModal;
+    HTMLDialogElement.prototype.close = originalClose;
+    Element.prototype.animate = originalAnimate;
+  });
+
+  it("dismisses when the click lands outside the sheet bounds", async () => {
+    const onClose = vi.fn<() => void>();
+    const dialog = renderSheet(onClose);
+
+    await fireEvent.click(dialog, { clientX: 10, clientY: 10 });
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dismiss when the click lands on the sheet's own padding", async () => {
+    const onClose = vi.fn<() => void>();
+    const dialog = renderSheet(onClose);
+
+    await fireEvent.click(dialog, { clientX: 200, clientY: 200 });
+
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it("dismisses once when the close button is clicked, not twice via the dialog handler", async () => {
+    const onClose = vi.fn<() => void>();
+    renderSheet(onClose);
+
+    await fireEvent.click(screen.getByRole("button", { name: "閉じる" }));
+
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.test.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.test.ts
@@ -60,6 +60,27 @@ describe("swipeDownToDismiss", () => {
     expect(onDismiss).not.toHaveBeenCalled();
   });
 
+  it("hands the gesture back when a second finger joins mid-drag", () => {
+    const node = createNode();
+    swipeDownToDismiss(node, { onDismiss });
+
+    node.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 100 }));
+    node.dispatchEvent(
+      new TouchEvent("touchmove", {
+        touches: [
+          { clientX: 0, clientY: 250 } as Touch,
+          { clientX: 40, clientY: 260 } as Touch,
+        ],
+        cancelable: true,
+        bubbles: true,
+      }),
+    );
+    node.dispatchEvent(touchEvent("touchend", { clientX: 0, clientY: 250 }));
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(node.style.transform).toBe("");
+  });
+
   it("does not start a drag while the content is scrolled away from the top", () => {
     const node = createNode();
     Object.defineProperty(node, "scrollTop", { value: 40, configurable: true });

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.test.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { swipeDownToDismiss } from "./swipe-down-to-dismiss";
+
+function touchEvent(
+  type: string,
+  options: { clientX: number; clientY: number; cancelable?: boolean },
+): TouchEvent {
+  return new TouchEvent(type, {
+    touches: [{ clientX: options.clientX, clientY: options.clientY } as Touch],
+    cancelable: options.cancelable ?? true,
+    bubbles: true,
+  });
+}
+
+function createNode(): HTMLElement {
+  const node = document.createElement("div");
+  document.body.appendChild(node);
+  return node;
+}
+
+describe("swipeDownToDismiss", () => {
+  let onDismiss: ReturnType<typeof vi.fn<() => void>>;
+
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    onDismiss = vi.fn<() => void>();
+  });
+
+  it("dismisses when dragged down past the threshold", () => {
+    const node = createNode();
+    swipeDownToDismiss(node, { onDismiss });
+
+    node.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 100 }));
+    node.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 250 }));
+    node.dispatchEvent(touchEvent("touchend", { clientX: 0, clientY: 250 }));
+
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not dismiss when the drag is below the threshold", () => {
+    const node = createNode();
+    swipeDownToDismiss(node, { onDismiss });
+
+    node.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 100 }));
+    node.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 150 }));
+    node.dispatchEvent(touchEvent("touchend", { clientX: 0, clientY: 150 }));
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(node.style.transform).toBe("");
+  });
+
+  it("hands the gesture back when the drag is dominantly horizontal", () => {
+    const node = createNode();
+    swipeDownToDismiss(node, { onDismiss });
+
+    node.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 100 }));
+    node.dispatchEvent(touchEvent("touchmove", { clientX: 200, clientY: 150 }));
+    node.dispatchEvent(touchEvent("touchend", { clientX: 200, clientY: 150 }));
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("does not start a drag while the content is scrolled away from the top", () => {
+    const node = createNode();
+    Object.defineProperty(node, "scrollTop", { value: 40, configurable: true });
+    swipeDownToDismiss(node, { onDismiss });
+
+    node.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 100 }));
+    node.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 250 }));
+    node.dispatchEvent(touchEvent("touchend", { clientX: 0, clientY: 250 }));
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+
+  it("uses the latest callback after update", () => {
+    const node = createNode();
+    const next = vi.fn<() => void>();
+    const handle = swipeDownToDismiss(node, { onDismiss });
+
+    handle?.update?.({ onDismiss: next });
+
+    node.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 100 }));
+    node.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 250 }));
+    node.dispatchEvent(touchEvent("touchend", { clientX: 0, clientY: 250 }));
+
+    expect(onDismiss).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops reacting once destroyed", () => {
+    const node = createNode();
+    const handle = swipeDownToDismiss(node, { onDismiss });
+
+    handle?.destroy?.();
+
+    node.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 100 }));
+    node.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 250 }));
+    node.dispatchEvent(touchEvent("touchend", { clientX: 0, clientY: 250 }));
+
+    expect(onDismiss).not.toHaveBeenCalled();
+  });
+});

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.test.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.test.ts
@@ -65,6 +65,9 @@ describe("swipeDownToDismiss", () => {
     swipeDownToDismiss(node, { onDismiss });
 
     node.dispatchEvent(touchEvent("touchstart", { clientX: 0, clientY: 100 }));
+    node.dispatchEvent(touchEvent("touchmove", { clientX: 0, clientY: 180 }));
+    expect(node.style.transform).not.toBe("");
+
     node.dispatchEvent(
       new TouchEvent("touchmove", {
         touches: [

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
@@ -89,6 +89,13 @@ export const swipeDownToDismiss: Action<
       return;
     }
 
+    // A second finger landing mid-drag means a pinch, not a dismiss; hand the
+    // gesture back to the browser so it can drive the multi-touch interaction.
+    if (event.touches.length !== 1) {
+      resetDrag(false);
+      return;
+    }
+
     const deltaX = event.touches[0].clientX - state.startX;
     const deltaY = event.touches[0].clientY - state.startY;
 

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
@@ -15,6 +15,11 @@ type SwipeDownToDismissOptions = {
  * scrolling the content downward is never hijacked. Releasing below the
  * threshold animates the sheet back into place; releasing past it leaves the
  * sheet translated so the component's own exit transition continues the motion.
+ *
+ * The gesture is intentionally touch-only: it targets the mobile bottom-sheet
+ * interaction where a downward swipe is the expected dismissal. Pointer and
+ * keyboard users dismiss the sheet through the backdrop, close button, or
+ * Escape instead.
  */
 export const swipeDownToDismiss: Action<
   HTMLElement,
@@ -28,23 +33,27 @@ export const swipeDownToDismiss: Action<
     dragging: false,
   };
 
-  function settle(): void {
-    node.style.transition = `transform ${RESET_TRANSITION_MS}ms ease-out`;
+  // `animate` distinguishes a release that springs back into place (touchend
+  // below the threshold, or a cancel) from one that must clear instantly so the
+  // browser regains the gesture (an upward or horizontal move mid-drag).
+  function resetDrag(animate: boolean): void {
+    if (animate) {
+      node.style.transition = `transform ${RESET_TRANSITION_MS}ms ease-out`;
+      setTimeout(() => {
+        if (node.isConnected) {
+          node.style.transition = "";
+        }
+      }, RESET_TRANSITION_MS);
+    } else {
+      node.style.transition = "";
+    }
     node.style.transform = "";
-    setTimeout(() => {
-      if (node.isConnected) {
-        node.style.transition = "";
-      }
-    }, RESET_TRANSITION_MS);
     state.dragging = false;
     state.deltaY = 0;
   }
 
-  function release(): void {
-    node.style.transition = "";
-    node.style.transform = "";
-    state.dragging = false;
-    state.deltaY = 0;
+  function onTouchCancel(): void {
+    resetDrag(true);
   }
 
   function onTouchStart(event: TouchEvent): void {
@@ -69,7 +78,7 @@ export const swipeDownToDismiss: Action<
     // Upward or dominantly horizontal motion is not a dismiss gesture; hand it
     // back to the browser so scrolling and horizontal swipes still work.
     if (deltaY <= 0 || Math.abs(deltaX) > deltaY) {
-      release();
+      resetDrag(false);
       return;
     }
 
@@ -92,13 +101,13 @@ export const swipeDownToDismiss: Action<
       return;
     }
 
-    settle();
+    resetDrag(true);
   }
 
   node.addEventListener("touchstart", onTouchStart, { passive: true });
   node.addEventListener("touchmove", onTouchMove, { passive: false });
   node.addEventListener("touchend", onTouchEnd);
-  node.addEventListener("touchcancel", settle);
+  node.addEventListener("touchcancel", onTouchCancel);
 
   return {
     update(next: SwipeDownToDismissOptions): void {
@@ -108,7 +117,7 @@ export const swipeDownToDismiss: Action<
       node.removeEventListener("touchstart", onTouchStart);
       node.removeEventListener("touchmove", onTouchMove);
       node.removeEventListener("touchend", onTouchEnd);
-      node.removeEventListener("touchcancel", settle);
+      node.removeEventListener("touchcancel", onTouchCancel);
     },
   };
 };

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
@@ -1,0 +1,114 @@
+import type { Action } from "svelte/action";
+
+const DISMISS_THRESHOLD_PX = 100;
+const RESET_TRANSITION_MS = 200;
+
+type SwipeDownToDismissOptions = {
+  /** Invoked once the sheet is dragged down far enough to dismiss it. */
+  onDismiss: () => void;
+};
+
+/**
+ * Lets a bottom sheet be closed with a downward swipe.
+ *
+ * The drag only engages when the scroll container is already at the top, so
+ * scrolling the content downward is never hijacked. Releasing below the
+ * threshold animates the sheet back into place; releasing past it leaves the
+ * sheet translated so the component's own exit transition continues the motion.
+ */
+export const swipeDownToDismiss: Action<
+  HTMLElement,
+  SwipeDownToDismissOptions
+> = (node, options) => {
+  let current = options;
+  const state = {
+    startX: 0,
+    startY: 0,
+    deltaY: 0,
+    dragging: false,
+  };
+
+  function settle(): void {
+    node.style.transition = `transform ${RESET_TRANSITION_MS}ms ease-out`;
+    node.style.transform = "";
+    setTimeout(() => {
+      if (node.isConnected) {
+        node.style.transition = "";
+      }
+    }, RESET_TRANSITION_MS);
+    state.dragging = false;
+    state.deltaY = 0;
+  }
+
+  function release(): void {
+    node.style.transition = "";
+    node.style.transform = "";
+    state.dragging = false;
+    state.deltaY = 0;
+  }
+
+  function onTouchStart(event: TouchEvent): void {
+    if (node.scrollTop > 0 || event.touches.length !== 1) {
+      return;
+    }
+    state.startX = event.touches[0].clientX;
+    state.startY = event.touches[0].clientY;
+    state.deltaY = 0;
+    state.dragging = true;
+    node.style.transition = "none";
+  }
+
+  function onTouchMove(event: TouchEvent): void {
+    if (!state.dragging) {
+      return;
+    }
+
+    const deltaX = event.touches[0].clientX - state.startX;
+    const deltaY = event.touches[0].clientY - state.startY;
+
+    // Upward or dominantly horizontal motion is not a dismiss gesture; hand it
+    // back to the browser so scrolling and horizontal swipes still work.
+    if (deltaY <= 0 || Math.abs(deltaX) > deltaY) {
+      release();
+      return;
+    }
+
+    if (event.cancelable) {
+      event.preventDefault();
+    }
+    state.deltaY = deltaY;
+    node.style.transform = `translate3d(0, ${deltaY}px, 0)`;
+  }
+
+  function onTouchEnd(): void {
+    if (!state.dragging) {
+      return;
+    }
+
+    if (state.deltaY > DISMISS_THRESHOLD_PX) {
+      // Keep the translation so the exit transition continues from here.
+      state.dragging = false;
+      current.onDismiss();
+      return;
+    }
+
+    settle();
+  }
+
+  node.addEventListener("touchstart", onTouchStart, { passive: true });
+  node.addEventListener("touchmove", onTouchMove, { passive: false });
+  node.addEventListener("touchend", onTouchEnd);
+  node.addEventListener("touchcancel", settle);
+
+  return {
+    update(next: SwipeDownToDismissOptions): void {
+      current = next;
+    },
+    destroy(): void {
+      node.removeEventListener("touchstart", onTouchStart);
+      node.removeEventListener("touchmove", onTouchMove);
+      node.removeEventListener("touchend", onTouchEnd);
+      node.removeEventListener("touchcancel", settle);
+    },
+  };
+};

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
@@ -66,6 +66,9 @@ export const swipeDownToDismiss: Action<
   }
 
   function onTouchCancel(): void {
+    if (!state.dragging) {
+      return;
+    }
     resetDrag(true);
   }
 

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
@@ -11,24 +11,18 @@ type SwipeDownToDismissOptions = {
 /**
  * Lets a bottom sheet be closed with a downward swipe.
  *
- * The drag only engages when the scroll container is already at the top, so
- * scrolling the content downward is never hijacked. Releasing below the
- * threshold animates the sheet back into place; releasing past it leaves the
- * sheet translated so the component's own exit transition continues the motion.
- *
- * The gesture is intentionally touch-only: it targets the mobile bottom-sheet
- * interaction where a downward swipe is the expected dismissal. Pointer and
- * keyboard users dismiss the sheet through the backdrop, close button, or
- * Escape instead.
+ * Touch-only by design. It engages only when the scroll container is at the top
+ * so content scrolling is never hijacked, and past the threshold it leaves the
+ * sheet translated so the component's exit transition continues the motion.
+ * Pointer and keyboard users dismiss via the backdrop, close button, or Escape.
  */
 export const swipeDownToDismiss: Action<
   HTMLElement,
   SwipeDownToDismissOptions
 > = (node, options) => {
   let current = options;
-  // Tracks the pending timeout that clears the snap-back transition. A stale
-  // timeout firing mid-animation would reset `transition` and cut a later
-  // snap-back short, so every new reset or touch start clears the previous one.
+  // A stale snap-back timeout firing mid-animation would clear `transition` and
+  // cut a later snap-back short, so it is cleared on each reset and touch start.
   let resetTimeoutId: ReturnType<typeof setTimeout> | undefined;
   const state = {
     startX: 0,
@@ -44,9 +38,8 @@ export const swipeDownToDismiss: Action<
     }
   }
 
-  // `animate` distinguishes a release that springs back into place (touchend
-  // below the threshold, or a cancel) from one that must clear instantly so the
-  // browser regains the gesture (an upward or horizontal move mid-drag).
+  // `animate` springs the sheet back (release below threshold, or cancel); the
+  // instant path hands the gesture back to the browser mid-drag.
   function resetDrag(animate: boolean): void {
     clearResetTimeout();
     if (animate) {
@@ -89,8 +82,7 @@ export const swipeDownToDismiss: Action<
       return;
     }
 
-    // A second finger landing mid-drag means a pinch, not a dismiss; hand the
-    // gesture back to the browser so it can drive the multi-touch interaction.
+    // A second finger mid-drag is a pinch, not a dismiss; hand it back.
     if (event.touches.length !== 1) {
       resetDrag(false);
       return;
@@ -99,8 +91,8 @@ export const swipeDownToDismiss: Action<
     const deltaX = event.touches[0].clientX - state.startX;
     const deltaY = event.touches[0].clientY - state.startY;
 
-    // Upward or dominantly horizontal motion is not a dismiss gesture; hand it
-    // back to the browser so scrolling and horizontal swipes still work.
+    // Upward or dominantly horizontal motion is not a dismiss; hand it back so
+    // scrolling and horizontal swipes still work.
     if (deltaY <= 0 || Math.abs(deltaX) > deltaY) {
       resetDrag(false);
       return;

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
@@ -26,6 +26,10 @@ export const swipeDownToDismiss: Action<
   SwipeDownToDismissOptions
 > = (node, options) => {
   let current = options;
+  // Tracks the pending timeout that clears the snap-back transition. A stale
+  // timeout firing mid-animation would reset `transition` and cut a later
+  // snap-back short, so every new reset or touch start clears the previous one.
+  let resetTimeoutId: ReturnType<typeof setTimeout> | undefined;
   const state = {
     startX: 0,
     startY: 0,
@@ -33,13 +37,22 @@ export const swipeDownToDismiss: Action<
     dragging: false,
   };
 
+  function clearResetTimeout(): void {
+    if (resetTimeoutId !== undefined) {
+      clearTimeout(resetTimeoutId);
+      resetTimeoutId = undefined;
+    }
+  }
+
   // `animate` distinguishes a release that springs back into place (touchend
   // below the threshold, or a cancel) from one that must clear instantly so the
   // browser regains the gesture (an upward or horizontal move mid-drag).
   function resetDrag(animate: boolean): void {
+    clearResetTimeout();
     if (animate) {
       node.style.transition = `transform ${RESET_TRANSITION_MS}ms ease-out`;
-      setTimeout(() => {
+      resetTimeoutId = setTimeout(() => {
+        resetTimeoutId = undefined;
         if (node.isConnected) {
           node.style.transition = "";
         }
@@ -60,6 +73,7 @@ export const swipeDownToDismiss: Action<
     if (node.scrollTop > 0 || event.touches.length !== 1) {
       return;
     }
+    clearResetTimeout();
     state.startX = event.touches[0].clientX;
     state.startY = event.touches[0].clientY;
     state.deltaY = 0;
@@ -114,6 +128,7 @@ export const swipeDownToDismiss: Action<
       current = next;
     },
     destroy(): void {
+      clearResetTimeout();
       node.removeEventListener("touchstart", onTouchStart);
       node.removeEventListener("touchmove", onTouchMove);
       node.removeEventListener("touchend", onTouchEnd);

--- a/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
+++ b/packages/site/src/lib/utils/swipe-down-to-dismiss.ts
@@ -21,8 +21,8 @@ export const swipeDownToDismiss: Action<
   SwipeDownToDismissOptions
 > = (node, options) => {
   let current = options;
-  // A stale snap-back timeout firing mid-animation would clear `transition` and
-  // cut a later snap-back short, so it is cleared on each reset and touch start.
+  // Not fire-and-forget: a stale timeout would clear `transition` mid-animation
+  // and cut a later snap-back short, so it is cleared on each reset and start.
   let resetTimeoutId: ReturnType<typeof setTimeout> | undefined;
   const state = {
     startX: 0,
@@ -38,8 +38,8 @@ export const swipeDownToDismiss: Action<
     }
   }
 
-  // `animate` springs the sheet back (release below threshold, or cancel); the
-  // instant path hands the gesture back to the browser mid-drag.
+  // Not always animated: handing the gesture back mid-drag must clear instantly,
+  // or the browser's scroll/zoom would lag a frame behind the easing.
   function resetDrag(animate: boolean): void {
     clearResetTimeout();
     if (animate) {
@@ -82,7 +82,8 @@ export const swipeDownToDismiss: Action<
       return;
     }
 
-    // A second finger mid-drag is a pinch, not a dismiss; hand it back.
+    // Don't keep dragging off the first finger: a second one means a pinch, so
+    // hand the gesture back to the browser instead.
     if (event.touches.length !== 1) {
       resetDrag(false);
       return;
@@ -91,8 +92,8 @@ export const swipeDownToDismiss: Action<
     const deltaX = event.touches[0].clientX - state.startX;
     const deltaY = event.touches[0].clientY - state.startY;
 
-    // Upward or dominantly horizontal motion is not a dismiss; hand it back so
-    // scrolling and horizontal swipes still work.
+    // Don't capture upward or dominantly horizontal motion: preventing its
+    // default would break native scrolling and horizontal swipes, so hand back.
     if (deltaY <= 0 || Math.abs(deltaX) > deltaY) {
       resetDrag(false);
       return;


### PR DESCRIPTION
## Summary

Lets the card detail bottom sheet be dismissed with a downward swipe on touch devices.

## Details

The sheet could previously only be closed via the backdrop, close button, or Escape, none of which match the expected dismissal gesture for a mobile bottom sheet.

A touch-only Svelte action handles the drag, engaging only when the content is scrolled to the top so it never hijacks scrolling, and leaving the sheet translated on release so the existing exit transition continues the motion.

## Confirmation

Ran the unit tests (6 passing), svelte-check (0 errors, 0 warnings), and biome (clean) locally.

## Limitation

The gesture is intentionally touch-only; pointer and keyboard users continue to rely on the backdrop, close button, or Escape.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added swipe-down-to-dismiss gesture for modal/detail cards on touch devices.

* **Improvements**
  * Modal implementation updated to use the browser dialog with improved backdrop behavior, consistent Escape/backdrop close handling, and page-scroll lock while open.

* **Tests**
  * Added tests covering swipe-to-dismiss gestures and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->