### PR TITLE
feat: persist card preferences in the URL

### DIFF
--- a/packages/site/src/lib/utils/card-draw.test.ts
+++ b/packages/site/src/lib/utils/card-draw.test.ts
@@ -4,7 +4,7 @@ import {
   noAttack,
   type SelectionContext,
 } from "@heart-of-crown-randomizer/constraint";
-import { decodeIds } from "@heart-of-crown-randomizer/id-codec";
+import { decodeIds, encodeIds } from "@heart-of-crown-randomizer/id-codec";
 import { describe, expect, it } from "vitest";
 import { makeCard } from "$lib/test-helpers";
 import { buildCardUrl, drawMissingCommons, drawRandomCards } from "./card-draw";
@@ -197,27 +197,37 @@ describe("drawMissingCommons with constraints", () => {
 describe("buildCardUrl", () => {
   it("should update s while preserving p/e/c params from currentSearchParams", () => {
     const cards = [makeCard(1), makeCard(5)];
-    const searchParams = new URLSearchParams("s=stale&p=AQ&e=Ag&c=BA");
+    const pinned = encodeIds([2]);
+    const excluded = encodeIds([3]);
+    const constraints = encodeIds([4]);
+    const searchParams = new URLSearchParams(
+      `s=stale&p=${pinned}&e=${excluded}&c=${constraints}`,
+    );
 
     const result = buildCardUrl(cards, searchParams);
 
     const params = new URLSearchParams(result.slice(1));
     expect(new Set(decodeIds(params.get("s") ?? ""))).toEqual(new Set([1, 5]));
-    expect(params.get("p")).toBe("AQ");
-    expect(params.get("e")).toBe("Ag");
-    expect(params.get("c")).toBe("BA");
+    expect(params.get("p")).toBe(pinned);
+    expect(params.get("e")).toBe(excluded);
+    expect(params.get("c")).toBe(constraints);
   });
 
   it("should remove s when cards is empty but keep p/e/c", () => {
-    const searchParams = new URLSearchParams("s=stale&p=AQ&e=Ag&c=BA");
+    const pinned = encodeIds([2]);
+    const excluded = encodeIds([3]);
+    const constraints = encodeIds([4]);
+    const searchParams = new URLSearchParams(
+      `s=stale&p=${pinned}&e=${excluded}&c=${constraints}`,
+    );
 
     const result = buildCardUrl([], searchParams);
 
     const params = new URLSearchParams(result.slice(1));
     expect(params.has("s")).toBe(false);
-    expect(params.get("p")).toBe("AQ");
-    expect(params.get("e")).toBe("Ag");
-    expect(params.get("c")).toBe("BA");
+    expect(params.get("p")).toBe(pinned);
+    expect(params.get("e")).toBe(excluded);
+    expect(params.get("c")).toBe(constraints);
   });
 
   it("should preserve debug param from currentSearchParams", () => {

--- a/packages/site/src/lib/utils/card-draw.test.ts
+++ b/packages/site/src/lib/utils/card-draw.test.ts
@@ -195,16 +195,29 @@ describe("drawMissingCommons with constraints", () => {
 });
 
 describe("buildCardUrl", () => {
-  it("should include only compressed card IDs without p/e/c params", () => {
+  it("should update s while preserving p/e/c params from currentSearchParams", () => {
     const cards = [makeCard(1), makeCard(5)];
+    const searchParams = new URLSearchParams("s=stale&p=AQ&e=Ag&c=BA");
 
-    const result = buildCardUrl(cards);
+    const result = buildCardUrl(cards, searchParams);
 
     const params = new URLSearchParams(result.slice(1));
     expect(new Set(decodeIds(params.get("s") ?? ""))).toEqual(new Set([1, 5]));
-    expect(params.has("p")).toBe(false);
-    expect(params.has("e")).toBe(false);
-    expect(params.has("c")).toBe(false);
+    expect(params.get("p")).toBe("AQ");
+    expect(params.get("e")).toBe("Ag");
+    expect(params.get("c")).toBe("BA");
+  });
+
+  it("should remove s when cards is empty but keep p/e/c", () => {
+    const searchParams = new URLSearchParams("s=stale&p=AQ&e=Ag&c=BA");
+
+    const result = buildCardUrl([], searchParams);
+
+    const params = new URLSearchParams(result.slice(1));
+    expect(params.has("s")).toBe(false);
+    expect(params.get("p")).toBe("AQ");
+    expect(params.get("e")).toBe("Ag");
+    expect(params.get("c")).toBe("BA");
   });
 
   it("should preserve debug param from currentSearchParams", () => {

--- a/packages/site/src/lib/utils/card-draw.ts
+++ b/packages/site/src/lib/utils/card-draw.ts
@@ -89,23 +89,22 @@ export function drawMissingCommons(
 }
 
 /**
- * Build a navigation URL containing only the card selection and debug flag.
+ * Build a navigation URL that updates the card selection while carrying the
+ * rest of the query through.
  *
- * Pin/exclude/constraint state (p/e/c params) are intentionally omitted
- * because they serve as one-shot restore hints on direct page access, not
- * as continuously-synced state. Any navigation clears them from the URL.
+ * We copy the incoming params rather than rebuilding from scratch: pin/exclude/
+ * constraint (p/e/c) are continuously synced to the URL, so a fresh query would
+ * strip the preferences the user just set on every draw.
  */
 export function buildCardUrl(
   cards: CommonCard[],
   currentSearchParams?: URLSearchParams,
 ): string {
-  const params = new URLSearchParams();
+  const params = new URLSearchParams(currentSearchParams);
   if (cards.length > 0) {
     params.set("s", encodeIds(cards.map((c) => c.id)));
-  }
-  const debug = currentSearchParams?.get("debug");
-  if (debug != null) {
-    params.set("debug", debug);
+  } else {
+    params.delete("s");
   }
   return `?${params.toString()}`;
 }

--- a/packages/site/src/lib/utils/share.test.ts
+++ b/packages/site/src/lib/utils/share.test.ts
@@ -7,17 +7,27 @@ describe("buildShareUrl", () => {
   it("should build share URL with compressed 's' parameter that round-trips back to original card IDs", () => {
     const cards = [makeCard(1), makeCard(5), makeCard(12)];
 
-    const result = buildShareUrl("https://example.com", cards);
+    const result = buildShareUrl("https://example.com", cards, new Set());
 
-    expect(result).toMatch(/^https:\/\/example\.com\?s=.+$/);
     const sParam = new URL(result).searchParams.get("s") ?? "";
     expect(decodeIds(sParam)).toEqual([1, 5, 12]);
   });
 
   it("should return empty string for empty cards", () => {
-    const result = buildShareUrl("https://example.com", []);
+    const result = buildShareUrl("https://example.com", [], new Set());
 
     expect(result).toBe("");
+  });
+
+  it("should include constraints as 'c' while never emitting p/e", () => {
+    const cards = [makeCard(1)];
+
+    const result = buildShareUrl("https://example.com", cards, new Set([3, 7]));
+
+    const params = new URL(result).searchParams;
+    expect(decodeIds(params.get("c") ?? "")).toEqual([3, 7]);
+    expect(params.has("p")).toBe(false);
+    expect(params.has("e")).toBe(false);
   });
 });
 

--- a/packages/site/src/lib/utils/share.ts
+++ b/packages/site/src/lib/utils/share.ts
@@ -2,16 +2,27 @@ import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
 import { encodeIds } from "@heart-of-crown-randomizer/id-codec";
 
 /**
- * Build a shareable URL containing only card selection (no pin/exclude).
+ * Build a shareable URL with the card selection and the constraints behind it.
  *
- * We intentionally omit pin/exclude from the share URL because shared
- * links represent a specific card set, not the author's editing state.
+ * Unlike the live URL, we leave pin/exclude out: those are the author's personal
+ * editing state, whereas the constraints shape the draw the recipient sees, so
+ * only the constraints are worth carrying into a shared link.
  */
-export function buildShareUrl(origin: string, cards: CommonCard[]): string {
+export function buildShareUrl(
+  origin: string,
+  cards: CommonCard[],
+  constraintIds: ReadonlySet<number>,
+): string {
   if (cards.length === 0) {
     return "";
   }
-  return `${origin}?s=${encodeIds(cards.map((c) => c.id))}`;
+  const params = new URLSearchParams();
+  params.set("s", encodeIds(cards.map((c) => c.id)));
+  const encodedConstraints = encodeIds([...constraintIds]);
+  if (encodedConstraints) {
+    params.set("c", encodedConstraints);
+  }
+  return `${origin}?${params.toString()}`;
 }
 
 /**

--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -66,6 +66,16 @@
 		}
 	});
 
+	// Parse one preference param in isolation: a hand-edited, malformed value
+	// (decodeIds throws) drops only that param instead of discarding the others.
+	function parsePreferenceIds(url: URL, param: string): Set<number> {
+		try {
+			return parseCompressedIds(url, param);
+		} catch {
+			return new Set();
+		}
+	}
+
 	/**
 	 * Restore pin/exclude/constraint state from the URL on initial page load.
 	 *
@@ -75,19 +85,9 @@
 	 */
 	onMount(() => {
 		const url = $page.url;
-		let pinnedIds: Set<number>;
-		let excludedIds: Set<number>;
-		let constraintIds: Set<number>;
-		try {
-			pinnedIds = parseCompressedIds(url, "p");
-			excludedIds = parseCompressedIds(url, "e");
-			constraintIds = parseCompressedIds(url, "c");
-		} catch {
-			// A hand-edited, malformed param should not crash the page load.
-			pinnedIds = new Set();
-			excludedIds = new Set();
-			constraintIds = new Set();
-		}
+		const pinnedIds = parsePreferenceIds(url, "p");
+		const excludedIds = parsePreferenceIds(url, "e");
+		const constraintIds = parsePreferenceIds(url, "c");
 
 		// Pin takes precedence over exclude for overlapping IDs
 		for (const id of pinnedIds) {

--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -33,7 +33,7 @@
 	} from "$lib/utils/card-draw";
 	import { buildShareUrl, shareOrCopy } from "$lib/utils/share";
 	import { createSwipeHandlers } from "$lib/utils/swipe-gesture.svelte";
-	import { buildUrlWithCardState, parseCompressedIds, setsEqual } from "$lib/utils/url-sync";
+	import { buildUrlWithCardState, parseCompressedIds } from "$lib/utils/url-sync";
 
 	const isDebugMode = $derived($page.url.searchParams.get("debug") === "true");
 
@@ -109,48 +109,30 @@
 	 * Toggling a preference does not navigate on its own, so this effect is what
 	 * keeps the URL current.
 	 *
-	 * We gate on `restored` rather than letting it run on mount, because before
-	 * onMount seeds state the effect would compare empty state against a populated
-	 * URL and navigate the preferences away. replaceState keeps rapid toggles out
+	 * We gate on `restored` rather than running on mount: before onMount seeds
+	 * state the effect would see empty state against a populated URL and navigate
+	 * the preferences away. We hand `goto` the whole URL object, not just its
+	 * search, so the hash survives and an empty query still navigates to the bare
+	 * path instead of being a no-op. Comparing the rebuilt search against the
+	 * current one both prevents a navigation loop and lets a stale legacy
+	 * pin/exclude param get rewritten away. replaceState keeps rapid toggles out
 	 * of the history that draws push onto.
 	 */
 	$effect(() => {
+		if (!restored) {
+			return;
+		}
 		const pinnedIds = getPinnedCardIds();
 		const excludedIds = getExcludedCardIds();
 		const constraintIds = getEnabledConstraintIds();
 		const url = $page.url;
-		const ready = restored;
-		if (!ready) {
+
+		const nextUrl = buildUrlWithCardState(url, pinnedIds, excludedIds, constraintIds);
+		if (nextUrl.search === url.search) {
 			return;
 		}
 
-		let urlPinned: Set<number>;
-		let urlExcluded: Set<number>;
-		let urlConstraints: Set<number>;
-		try {
-			urlPinned = parseCompressedIds(url, "p");
-			urlExcluded = parseCompressedIds(url, "e");
-			urlConstraints = parseCompressedIds(url, "c");
-		} catch {
-			// Treat a malformed param as absent so it gets overwritten, not thrown.
-			urlPinned = new Set();
-			urlExcluded = new Set();
-			urlConstraints = new Set();
-		}
-
-		if (
-			setsEqual(urlPinned, pinnedIds) &&
-			setsEqual(urlExcluded, excludedIds) &&
-			setsEqual(urlConstraints, constraintIds)
-		) {
-			return;
-		}
-
-		goto(buildUrlWithCardState(url, pinnedIds, excludedIds, constraintIds).search, {
-			replaceState: true,
-			keepFocus: true,
-			noScroll: true,
-		});
+		goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
 	});
 
 	function drawRandomCards() {

--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -33,7 +33,7 @@
 	} from "$lib/utils/card-draw";
 	import { buildShareUrl, shareOrCopy } from "$lib/utils/share";
 	import { createSwipeHandlers } from "$lib/utils/swipe-gesture.svelte";
-	import { parseCompressedIds } from "$lib/utils/url-sync";
+	import { buildUrlWithCardState, parseCompressedIds, setsEqual } from "$lib/utils/url-sync";
 
 	const isDebugMode = $derived($page.url.searchParams.get("debug") === "true");
 
@@ -42,13 +42,17 @@
 	let shareUrl = $state("");
 	let errorMessage = $state("");
 	let detailCard: CommonCard | null = $state(null);
+	// Gates the preference-to-URL effect until onMount has restored state from the
+	// URL; without it the effect would run first against empty state and navigate
+	// the URL's preferences away before they are read back.
+	let restored = $state(false);
 
 	/**
 	 * We use $effect instead of $derived because buildShareUrl requires
 	 * window.location.origin, which is unavailable during SSR.
 	 */
 	$effect(() => {
-		shareUrl = buildShareUrl(window.location.origin, selectedCommons);
+		shareUrl = buildShareUrl(window.location.origin, selectedCommons, getEnabledConstraintIds());
 	});
 
 	$effect(() => {
@@ -63,17 +67,27 @@
 	});
 
 	/**
-	 * Restore pin/exclude/constraint state from URL on initial page load.
+	 * Restore pin/exclude/constraint state from the URL on initial page load.
 	 *
-	 * These params are one-shot hints: consumed once on direct access,
-	 * then cleared from the URL on the next navigation (card draw,
-	 * pin change, etc.) because buildCardUrl does not include them.
+	 * The params are kept in the URL continuously (see the effect below), so this
+	 * read is what restores the preferences after a reload, not just on a fresh
+	 * shared link.
 	 */
 	onMount(() => {
 		const url = $page.url;
-		const pinnedIds = parseCompressedIds(url, "p");
-		const excludedIds = parseCompressedIds(url, "e");
-		const constraintIds = parseCompressedIds(url, "c");
+		let pinnedIds: Set<number>;
+		let excludedIds: Set<number>;
+		let constraintIds: Set<number>;
+		try {
+			pinnedIds = parseCompressedIds(url, "p");
+			excludedIds = parseCompressedIds(url, "e");
+			constraintIds = parseCompressedIds(url, "c");
+		} catch {
+			// A hand-edited, malformed param should not crash the page load.
+			pinnedIds = new Set();
+			excludedIds = new Set();
+			constraintIds = new Set();
+		}
 
 		// Pin takes precedence over exclude for overlapping IDs
 		for (const id of pinnedIds) {
@@ -87,6 +101,56 @@
 		if (constraintIds.size > 0) {
 			setEnabledConstraintIds(constraintIds);
 		}
+		restored = true;
+	});
+
+	/**
+	 * Mirror pin/exclude/constraint state into the URL so a reload restores it.
+	 * Toggling a preference does not navigate on its own, so this effect is what
+	 * keeps the URL current.
+	 *
+	 * We gate on `restored` rather than letting it run on mount, because before
+	 * onMount seeds state the effect would compare empty state against a populated
+	 * URL and navigate the preferences away. replaceState keeps rapid toggles out
+	 * of the history that draws push onto.
+	 */
+	$effect(() => {
+		const pinnedIds = getPinnedCardIds();
+		const excludedIds = getExcludedCardIds();
+		const constraintIds = getEnabledConstraintIds();
+		const url = $page.url;
+		const ready = restored;
+		if (!ready) {
+			return;
+		}
+
+		let urlPinned: Set<number>;
+		let urlExcluded: Set<number>;
+		let urlConstraints: Set<number>;
+		try {
+			urlPinned = parseCompressedIds(url, "p");
+			urlExcluded = parseCompressedIds(url, "e");
+			urlConstraints = parseCompressedIds(url, "c");
+		} catch {
+			// Treat a malformed param as absent so it gets overwritten, not thrown.
+			urlPinned = new Set();
+			urlExcluded = new Set();
+			urlConstraints = new Set();
+		}
+
+		if (
+			setsEqual(urlPinned, pinnedIds) &&
+			setsEqual(urlExcluded, excludedIds) &&
+			setsEqual(urlConstraints, constraintIds)
+		) {
+			return;
+		}
+
+		goto(buildUrlWithCardState(url, pinnedIds, excludedIds, constraintIds).search, {
+			replaceState: true,
+			keepFocus: true,
+			noScroll: true,
+		});
 	});
 
 	function drawRandomCards() {

--- a/packages/site/src/routes/page.debug-mode.e2e.test.ts
+++ b/packages/site/src/routes/page.debug-mode.e2e.test.ts
@@ -67,7 +67,7 @@ describe("Debug Mode E2E: debug param preservation", () => {
       throw new Error("draw failed");
     }
 
-    const shareUrl = buildShareUrl("http://localhost", result.cards);
+    const shareUrl = buildShareUrl("http://localhost", result.cards, new Set());
 
     const url = new URL(shareUrl);
     expect(url.searchParams.get("debug")).toBeNull();

--- a/packages/site/src/routes/page.url-reactivity.test.ts
+++ b/packages/site/src/routes/page.url-reactivity.test.ts
@@ -36,10 +36,22 @@ describe("+page.svelte URL Reactivity Bug", () => {
   });
 
   it("should have separate $effect blocks for different concerns", () => {
-    // Expected: Separate effects for localStorage, URL params, and shareUrl updates
-    // This helps with proper dependency tracking
+    // Separate effects for shareUrl, URL-to-selection, and preference-to-URL,
+    // which helps with proper dependency tracking.
     const effectCount = (pageContent.match(/\$effect\(/g) || []).length;
-    expect(effectCount).toBeGreaterThanOrEqual(2);
+    expect(effectCount).toBeGreaterThanOrEqual(3);
+  });
+
+  it("should mirror preference state into the URL with replaceState", () => {
+    expect(pageContent).toContain("buildUrlWithCardState");
+    expect(pageContent).toMatch(/replaceState:\s*true/);
+  });
+
+  it("should gate the preference-to-URL effect until restore completes", () => {
+    // Without this guard the effect runs before onMount seeds state and wipes
+    // the URL's preferences; the flag pins that mitigation in place.
+    expect(pageContent).toMatch(/let restored = \$state\(false\)/);
+    expect(pageContent).toContain("if (!ready)");
   });
 
   it("should use $page store syntax for accessing URL", () => {

--- a/packages/site/src/routes/page.url-reactivity.test.ts
+++ b/packages/site/src/routes/page.url-reactivity.test.ts
@@ -51,7 +51,7 @@ describe("+page.svelte URL Reactivity Bug", () => {
     // Without this guard the effect runs before onMount seeds state and wipes
     // the URL's preferences; the flag pins that mitigation in place.
     expect(pageContent).toMatch(/let restored = \$state\(false\)/);
-    expect(pageContent).toContain("if (!ready)");
+    expect(pageContent).toMatch(/!restored/);
   });
 
   it("should use $page store syntax for accessing URL", () => {


### PR DESCRIPTION
## Summary

Pin, exclude, and constraint selections now persist in the URL, so they survive a reload.

## Details

They were memory-only before. Now `buildCardUrl` carries `p`/`e`/`c` through on draws, and an effect writes them on toggle — gated by a `restored` flag so it cannot wipe them before the initial restore. Share links keep only the constraints and selection, not pin/exclude.

## Confirmation

Site tests (294), svelte-check, and biome/prettier are green. Verified in a browser that toggle, reload, draw, and share behave as intended.

## Limitation

Pin/exclude are in the live URL (needed for reload), so only the in-app share strips them to `s`+`c`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Share links now include active constraints.

* **Bug Fixes**
  * Improved robustness of URL parameter parsing to prevent errors from malformed data.
  * Enhanced URL synchronization with user preference selections to prevent navigation loops.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->