### PR TITLE
build: consume internal library packages as raw TypeScript

### DIFF
--- a/packages/constraint/package.json
+++ b/packages/constraint/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@heart-of-crown-randomizer/constraint",
   "version": "1.0.0",
+  "private": true,
   "description": "Preset constraint definitions for card selection",
   "keywords": [
     "constraint",

--- a/packages/constraint/package.json
+++ b/packages/constraint/package.json
@@ -10,20 +10,13 @@
   "license": "Zlib",
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs"
-    }
+    ".": "./src/index.ts"
   },
-  "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
   "scripts": {
-    "build": "tsdown",
     "check": "npm-run-all2 check:*",
     "check:biome": "biome ci .",
     "check:knip": "knip",
     "check:type": "tsgo --noEmit",
-    "clean": "rimraf dist",
     "fmt": "npm-run-all2 fmt:*",
     "fmt:biome": "biome check --write --unsafe .",
     "fmt:package": "sort-package-json",
@@ -41,9 +34,7 @@
     "@vitest/coverage-v8": "catalog:",
     "knip": "catalog:",
     "npm-run-all2": "catalog:",
-    "rimraf": "catalog:",
     "sort-package-json": "catalog:",
-    "tsdown": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/packages/constraint/tsdown.config.ts
+++ b/packages/constraint/tsdown.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "tsdown";
-
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm"],
-  outDir: "dist",
-  dts: true,
-  clean: true,
-});

--- a/packages/id-codec/package.json
+++ b/packages/id-codec/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@heart-of-crown-randomizer/id-codec",
   "version": "1.0.0",
+  "private": true,
   "description": "Bitfield-based encode/decode for ID sets",
   "keywords": [
     "id",

--- a/packages/id-codec/package.json
+++ b/packages/id-codec/package.json
@@ -11,20 +11,13 @@
   "license": "Zlib",
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs"
-    }
+    ".": "./src/index.ts"
   },
-  "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
   "scripts": {
-    "build": "tsdown",
     "check": "npm-run-all2 check:*",
     "check:biome": "biome ci .",
     "check:knip": "knip",
     "check:type": "tsgo --noEmit",
-    "clean": "rimraf dist",
     "fmt": "npm-run-all2 fmt:*",
     "fmt:biome": "biome check --write --unsafe .",
     "fmt:package": "sort-package-json",
@@ -38,9 +31,7 @@
     "@vitest/coverage-v8": "catalog:",
     "knip": "catalog:",
     "npm-run-all2": "catalog:",
-    "rimraf": "catalog:",
     "sort-package-json": "catalog:",
-    "tsdown": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/packages/id-codec/tsdown.config.ts
+++ b/packages/id-codec/tsdown.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "tsdown";
-
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm"],
-  outDir: "dist",
-  dts: true,
-  clean: true,
-});

--- a/packages/randomizer/package.json
+++ b/packages/randomizer/package.json
@@ -12,20 +12,13 @@
   "license": "Zlib",
   "type": "module",
   "exports": {
-    ".": {
-      "types": "./dist/index.d.mts",
-      "import": "./dist/index.mjs"
-    }
+    ".": "./src/index.ts"
   },
-  "main": "dist/index.mjs",
-  "types": "dist/index.d.mts",
   "scripts": {
-    "build": "tsdown",
     "check": "npm-run-all2 check:*",
     "check:biome": "biome ci .",
     "check:knip": "knip",
     "check:type": "tsgo --noEmit",
-    "clean": "rimraf dist",
     "fmt": "npm-run-all2 fmt:*",
     "fmt:biome": "biome check --write --unsafe .",
     "fmt:package": "sort-package-json",
@@ -44,9 +37,7 @@
     "@vitest/coverage-v8": "catalog:",
     "knip": "catalog:",
     "npm-run-all2": "catalog:",
-    "rimraf": "catalog:",
     "sort-package-json": "catalog:",
-    "tsdown": "catalog:",
     "vitest": "catalog:"
   }
 }

--- a/packages/randomizer/package.json
+++ b/packages/randomizer/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@heart-of-crown-randomizer/randomizer",
   "version": "1.0.0",
+  "private": true,
   "description": "Testable card randomization library with deterministic seeding",
   "keywords": [
     "randomizer",

--- a/packages/randomizer/tsdown.config.ts
+++ b/packages/randomizer/tsdown.config.ts
@@ -1,9 +1,0 @@
-import { defineConfig } from "tsdown";
-
-export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm"],
-  outDir: "dist",
-  dts: true,
-  clean: true,
-});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -319,15 +319,9 @@ importers:
       npm-run-all2:
         specifier: 'catalog:'
         version: 9.0.2
-      rimraf:
-        specifier: 'catalog:'
-        version: 6.1.3
       sort-package-json:
         specifier: 'catalog:'
         version: 4.0.0
-      tsdown:
-        specifier: 'catalog:'
-        version: 0.22.2(@typescript/native-preview@7.0.0-dev.20260629.1)(oxc-resolver@11.21.3)(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -349,15 +343,9 @@ importers:
       npm-run-all2:
         specifier: 'catalog:'
         version: 9.0.2
-      rimraf:
-        specifier: 'catalog:'
-        version: 6.1.3
       sort-package-json:
         specifier: 'catalog:'
         version: 4.0.0
-      tsdown:
-        specifier: 'catalog:'
-        version: 0.22.2(@typescript/native-preview@7.0.0-dev.20260629.1)(oxc-resolver@11.21.3)(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))
@@ -389,15 +377,9 @@ importers:
       npm-run-all2:
         specifier: 'catalog:'
         version: 9.0.2
-      rimraf:
-        specifier: 'catalog:'
-        version: 6.1.3
       sort-package-json:
         specifier: 'catalog:'
         version: 4.0.0
-      tsdown:
-        specifier: 'catalog:'
-        version: 0.22.2(@typescript/native-preview@7.0.0-dev.20260629.1)(oxc-resolver@11.21.3)(typescript@6.0.3)
       vitest:
         specifier: 'catalog:'
         version: 4.1.9(@types/node@24.13.2)(@vitest/browser-playwright@4.1.9)(@vitest/coverage-v8@4.1.9)(jsdom@29.1.1)(vite@8.1.0(@types/node@24.13.2)(esbuild@0.28.1)(jiti@2.7.0)(yaml@2.9.0))

--- a/turbo.json
+++ b/turbo.json
@@ -6,20 +6,10 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": [
-        "@heart-of-crown-randomizer/card#build",
-        "@heart-of-crown-randomizer/id-codec#build",
-        "@heart-of-crown-randomizer/constraint#build",
-        "@heart-of-crown-randomizer/randomizer#build"
-      ]
+      "dependsOn": ["@heart-of-crown-randomizer/card#build"]
     },
     "check": {
-      "dependsOn": [
-        "@heart-of-crown-randomizer/card#build",
-        "@heart-of-crown-randomizer/id-codec#build",
-        "@heart-of-crown-randomizer/constraint#build",
-        "@heart-of-crown-randomizer/randomizer#build"
-      ]
+      "dependsOn": ["@heart-of-crown-randomizer/card#build"]
     },
     "test": {},
     "build": {

--- a/turbo.json
+++ b/turbo.json
@@ -6,10 +6,10 @@
     "dev": {
       "cache": false,
       "persistent": true,
-      "dependsOn": ["@heart-of-crown-randomizer/card#build"]
+      "dependsOn": ["^build"]
     },
     "check": {
-      "dependsOn": ["@heart-of-crown-randomizer/card#build"]
+      "dependsOn": ["^build"]
     },
     "test": {},
     "build": {


### PR DESCRIPTION
## Summary

Point the `exports` of `id-codec`, `randomizer`, and `constraint` at their TypeScript sources and drop their tsdown build step.

## Details

These packages are internal-only and every consumer (Vite, Vitest, svelte-check, tsgo) resolves them with bundler module resolution, so the build step only added dev/check startup latency and a risk of stale `dist` output.

The `card` package keeps its build because the dedent plugin flattens tagged templates at build time; dropping it would shift that work into every visitor's browser.

## Confirmation

Ran `pnpm build`, `pnpm test` (294 tests), and `pnpm check` (biome, knip, tsgo, svelte-check) at the repository root and all passed.

## Limitation

No known limitations.

https://claude.ai/code/session_01UUXFugio28xcAFbtnLT4mT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package entrypoints to load directly from source, simplifying package resolution across modules.
  * Removed unused build and cleanup tooling from multiple packages, reducing maintenance overhead.
  * Adjusted task dependencies so checks now run against a single build target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->