### PR TITLE
refactor: replace Set-reassignment workaround with SvelteSet

### DIFF
--- a/packages/site/src/lib/stores/card-state.svelte.ts
+++ b/packages/site/src/lib/stores/card-state.svelte.ts
@@ -1,51 +1,53 @@
 import type { CommonCard } from "@heart-of-crown-randomizer/card/type";
+import { SvelteSet } from "svelte/reactivity";
 
 export type CardStateType = "normal" | "pinned" | "excluded";
 
 /**
- * We reassign entire Sets rather than mutating them because Svelte 5's
- * $state proxy does not reliably propagate Set.add()/delete() mutations
- * to $derived in other modules. Property reassignment guarantees the
- * proxy detects the change.
+ * We use SvelteSet rather than a plain Set inside a $state proxy because
+ * the proxy does not propagate Set.add()/delete() mutations to $derived
+ * in other modules; SvelteSet makes those mutations observable directly.
  */
-const state = $state({
-  pinnedCardIds: new Set<number>(),
-  excludedCardIds: new Set<number>(),
-});
+const pinnedCardIds = new SvelteSet<number>();
+const excludedCardIds = new SvelteSet<number>();
+
+function replaceWith(
+  target: SvelteSet<number>,
+  ids: ReadonlySet<number>,
+): void {
+  target.clear();
+  for (const id of ids) {
+    target.add(id);
+  }
+}
 
 export function getPinnedCardIds(): ReadonlySet<number> {
-  return state.pinnedCardIds;
+  return pinnedCardIds;
 }
 
 export function getExcludedCardIds(): ReadonlySet<number> {
-  return state.excludedCardIds;
+  return excludedCardIds;
 }
 
 export function setPinnedCardIds(ids: Set<number>): void {
-  const nextPinned = new Set(ids);
-  const nextExcluded = new Set(state.excludedCardIds);
-  for (const id of nextPinned) {
-    nextExcluded.delete(id);
+  replaceWith(pinnedCardIds, ids);
+  for (const id of ids) {
+    excludedCardIds.delete(id);
   }
-  state.pinnedCardIds = nextPinned;
-  state.excludedCardIds = nextExcluded;
 }
 
 export function setExcludedCardIds(ids: Set<number>): void {
-  const nextExcluded = new Set(ids);
-  const nextPinned = new Set(state.pinnedCardIds);
-  for (const id of nextExcluded) {
-    nextPinned.delete(id);
+  replaceWith(excludedCardIds, ids);
+  for (const id of ids) {
+    pinnedCardIds.delete(id);
   }
-  state.excludedCardIds = nextExcluded;
-  state.pinnedCardIds = nextPinned;
 }
 
 export function getCardState(cardId: number): CardStateType {
-  if (state.pinnedCardIds.has(cardId)) {
+  if (pinnedCardIds.has(cardId)) {
     return "pinned";
   }
-  if (state.excludedCardIds.has(cardId)) {
+  if (excludedCardIds.has(cardId)) {
     return "excluded";
   }
   return "normal";
@@ -57,18 +59,12 @@ export function getCardState(cardId: number): CardStateType {
  * button click and users expect immediate state change.
  */
 export function togglePin(cardId: number): void {
-  const nextPinned = new Set(state.pinnedCardIds);
-  const nextExcluded = new Set(state.excludedCardIds);
-
-  if (nextPinned.has(cardId)) {
-    nextPinned.delete(cardId);
+  if (pinnedCardIds.has(cardId)) {
+    pinnedCardIds.delete(cardId);
   } else {
-    nextPinned.add(cardId);
-    nextExcluded.delete(cardId); // Cannot be both pinned and excluded
+    pinnedCardIds.add(cardId);
+    excludedCardIds.delete(cardId); // Cannot be both pinned and excluded
   }
-
-  state.pinnedCardIds = nextPinned;
-  state.excludedCardIds = nextExcluded;
 }
 
 /**
@@ -77,24 +73,18 @@ export function togglePin(cardId: number): void {
  * button click and users expect immediate state change.
  */
 export function toggleExclude(cardId: number): void {
-  const nextPinned = new Set(state.pinnedCardIds);
-  const nextExcluded = new Set(state.excludedCardIds);
-
-  if (nextExcluded.has(cardId)) {
-    nextExcluded.delete(cardId);
+  if (excludedCardIds.has(cardId)) {
+    excludedCardIds.delete(cardId);
   } else {
-    nextExcluded.add(cardId);
-    nextPinned.delete(cardId); // Cannot be both excluded and pinned
+    excludedCardIds.add(cardId);
+    pinnedCardIds.delete(cardId); // Cannot be both excluded and pinned
   }
-
-  state.pinnedCardIds = nextPinned;
-  state.excludedCardIds = nextExcluded;
 }
 
 export function getPinnedCards(allCards: CommonCard[]): CommonCard[] {
-  return allCards.filter((card) => state.pinnedCardIds.has(card.id));
+  return allCards.filter((card) => pinnedCardIds.has(card.id));
 }
 
 export function getExcludedCards(allCards: CommonCard[]): CommonCard[] {
-  return allCards.filter((card) => state.excludedCardIds.has(card.id));
+  return allCards.filter((card) => excludedCardIds.has(card.id));
 }

--- a/packages/site/src/lib/stores/card-state.svelte.ts
+++ b/packages/site/src/lib/stores/card-state.svelte.ts
@@ -41,14 +41,14 @@ export function getExcludedCardIds(): ReadonlySet<number> {
   return excludedCardIds;
 }
 
-export function setPinnedCardIds(ids: Set<number>): void {
+export function setPinnedCardIds(ids: ReadonlySet<number>): void {
   replaceWith(pinnedCardIds, ids);
   for (const id of ids) {
     excludedCardIds.delete(id);
   }
 }
 
-export function setExcludedCardIds(ids: Set<number>): void {
+export function setExcludedCardIds(ids: ReadonlySet<number>): void {
   replaceWith(excludedCardIds, ids);
   for (const id of ids) {
     pinnedCardIds.delete(id);

--- a/packages/site/src/lib/stores/card-state.svelte.ts
+++ b/packages/site/src/lib/stores/card-state.svelte.ts
@@ -11,11 +11,23 @@ export type CardStateType = "normal" | "pinned" | "excluded";
 const pinnedCardIds = new SvelteSet<number>();
 const excludedCardIds = new SvelteSet<number>();
 
+/**
+ * We diff instead of clear-and-add because clearing would also empty an
+ * aliased input set and would invalidate subscribers of members that did
+ * not change.
+ */
 function replaceWith(
   target: SvelteSet<number>,
   ids: ReadonlySet<number>,
 ): void {
-  target.clear();
+  if (target === ids) {
+    return;
+  }
+  for (const id of target) {
+    if (!ids.has(id)) {
+      target.delete(id);
+    }
+  }
   for (const id of ids) {
     target.add(id);
   }

--- a/packages/site/src/lib/stores/constraint-state.svelte.ts
+++ b/packages/site/src/lib/stores/constraint-state.svelte.ts
@@ -22,9 +22,22 @@ export function toggleConstraint(id: number): void {
   }
 }
 
-/** Bulk-set the enabled constraint IDs (for URL restore). */
+/**
+ * Bulk-set the enabled constraint IDs (for URL restore).
+ *
+ * We diff instead of clear-and-add because clearing would also empty an
+ * aliased input set and would invalidate subscribers of members that did
+ * not change.
+ */
 export function setEnabledConstraintIds(ids: ReadonlySet<number>): void {
-  enabledIds.clear();
+  if (ids === enabledIds) {
+    return;
+  }
+  for (const id of enabledIds) {
+    if (!ids.has(id)) {
+      enabledIds.delete(id);
+    }
+  }
   for (const id of ids) {
     enabledIds.add(id);
   }

--- a/packages/site/src/lib/stores/constraint-state.svelte.ts
+++ b/packages/site/src/lib/stores/constraint-state.svelte.ts
@@ -1,38 +1,38 @@
 import type { Constraint } from "@heart-of-crown-randomizer/constraint";
+import { SvelteSet } from "svelte/reactivity";
 
 /**
- * We reassign the entire Set rather than mutating because Svelte 5's
- * $state proxy does not reliably propagate Set mutations to $derived
- * in other modules.
+ * We use SvelteSet rather than a plain Set inside a $state proxy because
+ * the proxy does not propagate Set mutations to $derived in other
+ * modules; SvelteSet makes those mutations observable directly.
  */
-const state = $state({
-  enabledIds: new Set<number>(),
-});
+const enabledIds = new SvelteSet<number>();
 
 /** Get the set of currently enabled constraint IDs. */
 export function getEnabledConstraintIds(): ReadonlySet<number> {
-  return state.enabledIds;
+  return enabledIds;
 }
 
 /** Toggle a constraint on/off by ID. */
 export function toggleConstraint(id: number): void {
-  const next = new Set(state.enabledIds);
-  if (next.has(id)) {
-    next.delete(id);
+  if (enabledIds.has(id)) {
+    enabledIds.delete(id);
   } else {
-    next.add(id);
+    enabledIds.add(id);
   }
-  state.enabledIds = next;
 }
 
 /** Bulk-set the enabled constraint IDs (for URL restore). */
 export function setEnabledConstraintIds(ids: ReadonlySet<number>): void {
-  state.enabledIds = new Set(ids);
+  enabledIds.clear();
+  for (const id of ids) {
+    enabledIds.add(id);
+  }
 }
 
 /** Get the enabled Constraint objects from a list of all available constraints. */
 export function getEnabledConstraints(
   allConstraints: readonly Constraint[],
 ): Constraint[] {
-  return allConstraints.filter((c) => state.enabledIds.has(c.id));
+  return allConstraints.filter((c) => enabledIds.has(c.id));
 }

--- a/packages/site/src/routes/page.full-flow.e2e.test.ts
+++ b/packages/site/src/routes/page.full-flow.e2e.test.ts
@@ -337,9 +337,9 @@ describe("Full Flow E2E: URL Sharing → State Restoration", () => {
     setExcludedCardIds(parseCompressedIds(url, "e"));
     setEnabledConstraintIds(parseCompressedIds(url, "c"));
 
-    expect(getPinnedCardIds()).toEqual(new Set([1, 5]));
-    expect(getExcludedCardIds()).toEqual(new Set([7]));
-    expect(getEnabledConstraintIds()).toEqual(new Set([3]));
+    expect(new Set(getPinnedCardIds())).toEqual(new Set([1, 5]));
+    expect(new Set(getExcludedCardIds())).toEqual(new Set([7]));
+    expect(new Set(getEnabledConstraintIds())).toEqual(new Set([3]));
   });
 
   it("should build URL with complete state for sharing", () => {

--- a/packages/site/src/routes/page.url-sync.test.ts
+++ b/packages/site/src/routes/page.url-sync.test.ts
@@ -219,9 +219,9 @@ describe("URL -> State sync (integration)", () => {
     setExcludedCardIds(parseCompressedIds(url, "e"));
     setEnabledConstraintIds(parseCompressedIds(url, "c"));
 
-    expect(getPinnedCardIds()).toEqual(new Set([1, 5]));
-    expect(getExcludedCardIds()).toEqual(new Set([7]));
-    expect(getEnabledConstraintIds()).toEqual(new Set([3]));
+    expect(new Set(getPinnedCardIds())).toEqual(new Set([1, 5]));
+    expect(new Set(getExcludedCardIds())).toEqual(new Set([7]));
+    expect(new Set(getEnabledConstraintIds())).toEqual(new Set([3]));
   });
 
   it("should clear state when URL has no state parameters", () => {


### PR DESCRIPTION
## Summary

Replace the whole-Set reassignment workaround in the pin/exclude/constraint stores with `SvelteSet` from `svelte/reactivity`.

## Details

A plain `Set` inside a `$state` proxy does not propagate `add()`/`delete()` mutations to `$derived` in other modules, so every update copied and reassigned the entire Set.

`SvelteSet` makes those mutations observable directly, which removes the copy-and-reassign ceremony and is the idiomatic Svelte 5 solution.

Test assertions comparing store contents against plain Sets now wrap the returned `SvelteSet` in `new Set()`, since `toEqual` distinguishes the two constructors.

## Confirmation

Ran the site test suite (294 tests), type-check, and biome locally; all passed.

## Limitation

No known limitations.

https://claude.ai/code/session_01UUXFugio28xcAFbtnLT4mT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of pinned, excluded, and enabled constraint selections to keep state consistent across navigation.
  - Fixed URL restoration/sync so selected items are preserved correctly when reloading or syncing from a compressed URL.
  - Prevented conflicts where the same item could be both pinned and excluded.
- **Tests**
  - Updated URL/state sync assertions to compare stable set contents instead of set identity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
