### PR TITLE
refactor: migrate page store from $app/stores to $app/state

### DIFF
--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -5,7 +5,7 @@
 	import { Plus, Shuffle } from "lucide-svelte";
 	import { onMount } from "svelte";
 	import { goto } from "$app/navigation";
-	import { page } from "$app/stores";
+	import { page } from "$app/state";
 	import AppMenu from "$lib/app-menu/AppMenu.svelte";
 	import Card from "$lib/Card.svelte";
 	import CardDetail from "$lib/CardDetail.svelte";
@@ -35,7 +35,7 @@
 	import { createSwipeHandlers } from "$lib/utils/swipe-gesture.svelte";
 	import { buildUrlWithCardState, parseCompressedIds } from "$lib/utils/url-sync";
 
-	const isDebugMode = $derived($page.url.searchParams.get("debug") === "true");
+	const isDebugMode = $derived(page.url.searchParams.get("debug") === "true");
 
 	let numberOfCommons = $state(10);
 	let selectedCommons: CommonCard[] = $state([]);
@@ -56,7 +56,7 @@
 	});
 
 	$effect(() => {
-		const newSelectedCommons = resolveCardsFromUrl($page.url, allCommons);
+		const newSelectedCommons = resolveCardsFromUrl(page.url, allCommons);
 		const idsMatch =
 			selectedCommons.length === newSelectedCommons.length &&
 			selectedCommons.every((card, i) => card.id === newSelectedCommons[i]?.id);
@@ -84,7 +84,7 @@
 	 * shared link.
 	 */
 	onMount(() => {
-		const url = $page.url;
+		const url = page.url;
 		const pinnedIds = parsePreferenceIds(url, "p");
 		const excludedIds = parsePreferenceIds(url, "e");
 		const constraintIds = parsePreferenceIds(url, "c");
@@ -125,7 +125,7 @@
 		const pinnedIds = getPinnedCardIds();
 		const excludedIds = getExcludedCardIds();
 		const constraintIds = getEnabledConstraintIds();
-		const url = $page.url;
+		const url = page.url;
 
 		const nextUrl = buildUrlWithCardState(url, pinnedIds, excludedIds, constraintIds);
 		if (nextUrl.search === url.search) {
@@ -156,7 +156,7 @@
 		selectedCommons = result.cards;
 		errorMessage = "";
 
-		goto(buildCardUrl(selectedCommons, $page.url.searchParams), {
+		goto(buildCardUrl(selectedCommons, page.url.searchParams), {
 			keepFocus: true,
 			noScroll: true,
 		});
@@ -175,7 +175,7 @@
 	}
 
 	function navigateWithCardState() {
-		goto(buildCardUrl(selectedCommons, $page.url.searchParams), {
+		goto(buildCardUrl(selectedCommons, page.url.searchParams), {
 			keepFocus: true,
 			noScroll: true,
 		});

--- a/packages/site/src/routes/page.reactivity.test.ts
+++ b/packages/site/src/routes/page.reactivity.test.ts
@@ -2,22 +2,23 @@ import { render, screen, waitFor } from "@testing-library/svelte";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import Page from "./+page.svelte";
 
-vi.mock("$app/stores", async () => {
-  const { writable } = await import("svelte/store");
-  return {
-    page: writable({
-      url: new URL("http://localhost?card=17&card=18&card=19"),
-      params: {},
-      route: { id: "/" },
-      status: 200,
-      error: null,
-      data: {},
-      form: null,
-    }),
-    navigating: writable(null),
-    updated: writable(false),
-  };
-});
+/**
+ * A plain object stands in for the rune-backed page state rather than a
+ * reactive mock: the URL is fixed for the whole file, so the component
+ * only reads the value and never needs to observe a change.
+ */
+vi.mock("$app/state", () => ({
+  page: {
+    url: new URL("http://localhost?card=17&card=18&card=19"),
+    params: {},
+    route: { id: "/" },
+    status: 200,
+    error: null,
+    data: {},
+    form: null,
+    state: {},
+  },
+}));
 
 vi.mock("$app/navigation", () => ({
   goto: vi.fn(),
@@ -53,9 +54,9 @@ describe("+page.svelte URL change reactivity", () => {
   it("should re-run effect when URL parameters change (after fix)", async () => {
     render(Page);
 
-    // Note: This test needs to be rewritten to work with svelteTesting() plugin
-    // The plugin provides static mocks, so dynamic URL changes require a different approach
-    // For now, we just verify initial rendering works
+    // Note: This test needs to be rewritten with a rune-backed page mock,
+    // because the static object above cannot notify the component of
+    // dynamic URL changes. For now, we just verify initial rendering works.
 
     await waitFor(() => {
       // After fix, the component should react to each URL change

--- a/packages/site/src/routes/page.svelte.test.ts
+++ b/packages/site/src/routes/page.svelte.test.ts
@@ -1,13 +1,15 @@
 import { encodeIds } from "@heart-of-crown-randomizer/id-codec";
-import type { Page } from "@sveltejs/kit";
 import { render, waitFor } from "@testing-library/svelte";
-import type { Writable } from "svelte/store";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import PageComponent from "./+page.svelte";
 
-vi.mock("$app/stores", async () => {
-  const { writable } = await import("svelte/store");
-  const pageStore = writable({
+/**
+ * A plain mutable object stands in for the rune-backed page state rather
+ * than a reactive mock: every test sets the URL before render, so the
+ * component only ever reads the value, never needs to observe a change.
+ */
+vi.mock("$app/state", () => ({
+  page: {
     url: new URL("http://localhost"),
     params: {},
     route: { id: "/" },
@@ -15,17 +17,18 @@ vi.mock("$app/stores", async () => {
     error: null,
     data: {},
     form: null,
-  });
-  return {
-    page: pageStore,
-    navigating: writable(null),
-    updated: writable(false),
-  };
-});
+    state: {},
+  },
+}));
 
 vi.mock("$app/navigation", () => ({
   goto: vi.fn(),
 }));
+
+async function setPageUrl(url: URL): Promise<void> {
+  const { page } = await import("$app/state");
+  (page as unknown as { url: URL }).url = url;
+}
 
 describe("+page.svelte URL parameter card restoration", () => {
   beforeEach(() => {
@@ -43,48 +46,18 @@ describe("+page.svelte URL parameter card restoration", () => {
   });
 
   it("should restore Basic cards from URL parameters", async () => {
-    const stores = await import("$app/stores");
-    const pageStore = stores.page as unknown as Writable<Page>;
-
-    const testUrl = new URL(`http://localhost?s=${encodeIds([17, 18, 19])}`);
-    pageStore.set({
-      url: testUrl as Page["url"],
-      params: {},
-      route: { id: "/" },
-      status: 200,
-      error: null,
-      data: {},
-      state: {},
-      form: null,
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setPageUrl(new URL(`http://localhost?s=${encodeIds([17, 18, 19])}`));
 
     const { container } = render(PageComponent);
 
-    await new Promise((resolve) => setTimeout(resolve, 500));
-
-    const cards = container.querySelectorAll(".card-swipeable");
-    expect(cards.length).toBe(3);
+    await waitFor(() => {
+      const cards = container.querySelectorAll(".card-swipeable");
+      expect(cards.length).toBe(3);
+    });
   });
 
   it("should restore Far Eastern Border cards from URL parameters", async () => {
-    const stores = await import("$app/stores");
-    const pageStore = stores.page as unknown as Writable<Page>;
-
-    const testUrl = new URL(`http://localhost?s=${encodeIds([49, 50, 51])}`);
-    pageStore.set({
-      url: testUrl as Page["url"],
-      params: {},
-      route: { id: "/" },
-      status: 200,
-      error: null,
-      data: {},
-      state: {},
-      form: null,
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await setPageUrl(new URL(`http://localhost?s=${encodeIds([49, 50, 51])}`));
 
     const { container } = render(PageComponent);
 
@@ -95,24 +68,9 @@ describe("+page.svelte URL parameter card restoration", () => {
   });
 
   it("should restore mixed Basic and Far Eastern Border cards", async () => {
-    const stores = await import("$app/stores");
-    const pageStore = stores.page as unknown as Writable<Page>;
-
-    const testUrl = new URL(
-      `http://localhost?s=${encodeIds([17, 18, 49, 50])}`,
+    await setPageUrl(
+      new URL(`http://localhost?s=${encodeIds([17, 18, 49, 50])}`),
     );
-    pageStore.set({
-      url: testUrl as Page["url"],
-      params: {},
-      route: { id: "/" },
-      status: 200,
-      error: null,
-      data: {},
-      state: {},
-      form: null,
-    });
-
-    await new Promise((resolve) => setTimeout(resolve, 0));
 
     const { container } = render(PageComponent);
 

--- a/packages/site/src/routes/page.url-reactivity.test.ts
+++ b/packages/site/src/routes/page.url-reactivity.test.ts
@@ -13,11 +13,11 @@ describe("+page.svelte URL Reactivity Bug", () => {
     pageContent = readFileSync(join(__dirname, "+page.svelte"), "utf-8");
   });
 
-  it("should use reactive page store from $app/stores", () => {
-    // The bug: Using non-reactive page from $app/state
-    // Expected: Should import from $app/stores for reactivity
-    expect(pageContent).toContain('import { page } from "$app/stores"');
-    expect(pageContent).not.toContain('import { page } from "$app/state"');
+  it("should use reactive page state from $app/state", () => {
+    // $app/stores is deprecated since SvelteKit 2.12; page.url from
+    // $app/state is fine-grained reactive when read inside $effect/$derived.
+    expect(pageContent).toContain('import { page } from "$app/state"');
+    expect(pageContent).not.toContain('import { page } from "$app/stores"');
   });
 
   it("should NOT use isInitialized guard that prevents reactivity", () => {
@@ -54,11 +54,11 @@ describe("+page.svelte URL Reactivity Bug", () => {
     expect(pageContent).toMatch(/!restored/);
   });
 
-  it("should use $page store syntax for accessing URL", () => {
-    // When using reactive page store, should use $page.url syntax
+  it("should read the URL as page.url, not the store subscription $page.url", () => {
     // URL param parsing is delegated to utility functions (resolveCardsFromUrl, parseCompressedIds)
-    if (pageContent.includes('from "$app/stores"')) {
-      expect(pageContent).toContain("$page.url");
+    if (pageContent.includes('from "$app/state"')) {
+      expect(pageContent).toContain("page.url");
+      expect(pageContent).not.toContain("$page.url");
     }
   });
 });
@@ -75,7 +75,7 @@ describe("+page.svelte URL Reactivity - Integration Behavior", () => {
 			Expected behavior after fix:
 			- When user navigates with browser back/forward buttons
 			- URL parameters change (e.g., ?card=1&card=2 -> ?card=3&card=4)
-			- $effect watching $page.url should re-run
+			- $effect watching page.url should re-run
 			- selectedCommons should update to reflect new URL
 			- shareUrl should update reactively
 


### PR DESCRIPTION
## Summary

Migrate `+page.svelte` from the deprecated `$app/stores` page store to the rune-backed `$app/state`.

## Details

`$app/stores` has been deprecated since SvelteKit 2.12, and `page.url` from `$app/state` is fine-grained reactive when read inside `$effect`/`$derived`, so the existing URL-sync effects keep working unchanged.

A characterization test pinned `$app/stores` with a comment claiming `$app/state` was non-reactive; that claim does not hold on current SvelteKit, so the test now pins the migrated import, and the store-based test mocks become plain objects because each test sets the URL before render.

## Confirmation

Ran the site test suite (294 tests), type-check, and biome locally; all passed.

## Limitation

Browser back/forward reactivity was not manually verified in a real browser.

https://claude.ai/code/session_01UUXFugio28xcAFbtnLT4mT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved URL-driven behavior so page state stays in sync with browser navigation and query parameter changes.
  * Restored preferences and card-related URLs more reliably when revisiting or updating the page.
* **Tests**
  * Updated coverage to match the new reactive page state behavior and URL update flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->