### PR TITLE
refactor: derive shareUrl instead of assigning it in an $effect

### DIFF
--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -4,6 +4,7 @@
 	import { allConstraints } from "@heart-of-crown-randomizer/constraint";
 	import { Plus, Shuffle } from "lucide-svelte";
 	import { onMount } from "svelte";
+	import { browser } from "$app/environment";
 	import { goto } from "$app/navigation";
 	import { page } from "$app/state";
 	import AppMenu from "$lib/app-menu/AppMenu.svelte";
@@ -39,7 +40,6 @@
 
 	let numberOfCommons = $state(10);
 	let selectedCommons: CommonCard[] = $state([]);
-	let shareUrl = $state("");
 	let errorMessage = $state("");
 	let detailCard: CommonCard | null = $state(null);
 	// Gates the preference-to-URL effect until onMount has restored state from the
@@ -48,12 +48,15 @@
 	let restored = $state(false);
 
 	/**
-	 * We use $effect instead of $derived because buildShareUrl requires
-	 * window.location.origin, which is unavailable during SSR.
+	 * We guard with `browser` instead of deriving unconditionally because
+	 * buildShareUrl requires window.location.origin, which is unavailable
+	 * during SSR.
 	 */
-	$effect(() => {
-		shareUrl = buildShareUrl(window.location.origin, selectedCommons, getEnabledConstraintIds());
-	});
+	const shareUrl = $derived(
+		browser
+			? buildShareUrl(window.location.origin, selectedCommons, getEnabledConstraintIds())
+			: "",
+	);
 
 	$effect(() => {
 		const newSelectedCommons = resolveCardsFromUrl(page.url, allCommons);

--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -4,7 +4,6 @@
 	import { allConstraints } from "@heart-of-crown-randomizer/constraint";
 	import { Plus, Shuffle } from "lucide-svelte";
 	import { onMount } from "svelte";
-	import { browser } from "$app/environment";
 	import { goto } from "$app/navigation";
 	import { page } from "$app/state";
 	import AppMenu from "$lib/app-menu/AppMenu.svelte";
@@ -48,14 +47,11 @@
 	let restored = $state(false);
 
 	/**
-	 * We guard with `browser` instead of deriving unconditionally because
-	 * buildShareUrl requires window.location.origin, which is unavailable
-	 * during SSR.
+	 * We take the origin from page.url rather than window.location because the
+	 * latter is undefined during SSR and would force a browser guard here.
 	 */
 	const shareUrl = $derived(
-		browser
-			? buildShareUrl(window.location.origin, selectedCommons, getEnabledConstraintIds())
-			: "",
+		buildShareUrl(page.url.origin, selectedCommons, getEnabledConstraintIds()),
 	);
 
 	$effect(() => {

--- a/packages/site/src/routes/page.url-reactivity.test.ts
+++ b/packages/site/src/routes/page.url-reactivity.test.ts
@@ -36,10 +36,11 @@ describe("+page.svelte URL Reactivity Bug", () => {
   });
 
   it("should have separate $effect blocks for different concerns", () => {
-    // Separate effects for shareUrl, URL-to-selection, and preference-to-URL,
-    // which helps with proper dependency tracking.
+    // Separate effects for URL-to-selection and preference-to-URL, which
+    // helps with proper dependency tracking; shareUrl is a $derived value
+    // rather than an effect.
     const effectCount = (pageContent.match(/\$effect\(/g) || []).length;
-    expect(effectCount).toBeGreaterThanOrEqual(3);
+    expect(effectCount).toBeGreaterThanOrEqual(2);
   });
 
   it("should mirror preference state into the URL with replaceState", () => {

--- a/packages/site/src/routes/page.url-reactivity.test.ts
+++ b/packages/site/src/routes/page.url-reactivity.test.ts
@@ -36,11 +36,16 @@ describe("+page.svelte URL Reactivity Bug", () => {
   });
 
   it("should have separate $effect blocks for different concerns", () => {
-    // Separate effects for URL-to-selection and preference-to-URL, which
-    // helps with proper dependency tracking; shareUrl is a $derived value
-    // rather than an effect.
+    // One combined effect was rejected: it would re-run every concern
+    // whenever any single dependency changed.
     const effectCount = (pageContent.match(/\$effect\(/g) || []).length;
     expect(effectCount).toBeGreaterThanOrEqual(2);
+  });
+
+  it("should derive shareUrl rather than assign it inside an $effect", () => {
+    expect(pageContent).toMatch(/const shareUrl = \$derived\(/);
+    expect(pageContent).not.toMatch(/let shareUrl = \$state\(/);
+    expect(pageContent).not.toMatch(/shareUrl = buildShareUrl\(/);
   });
 
   it("should mirror preference state into the URL with replaceState", () => {

--- a/packages/site/src/routes/page.url-reactivity.test.ts
+++ b/packages/site/src/routes/page.url-reactivity.test.ts
@@ -48,6 +48,15 @@ describe("+page.svelte URL Reactivity Bug", () => {
     expect(pageContent).not.toMatch(/shareUrl = buildShareUrl\(/);
   });
 
+  it("should build the share URL from an origin that survives SSR", () => {
+    expect(pageContent).toMatch(
+      /const shareUrl = \$derived\(\s*buildShareUrl\(page\.url\.origin/,
+    );
+    // window.location.origin was rejected: it is undefined during SSR, so it
+    // would drag a browser guard back into the derivation.
+    expect(pageContent).not.toContain("window.location.origin");
+  });
+
   it("should mirror preference state into the URL with replaceState", () => {
     expect(pageContent).toContain("buildUrlWithCardState");
     expect(pageContent).toMatch(/replaceState:\s*true/);


### PR DESCRIPTION
## Summary

Compute `shareUrl` with `$derived` instead of assigning a `$state` variable inside an `$effect`.

## Details

Assigning state inside `$effect` is a documented Svelte 5 anti-pattern, and the value is a pure function of the selection and enabled constraints.

The original effect existed only because `window.location.origin` is unavailable during SSR. The origin is now taken from `page.url` instead, which `$app/state` makes readable during server rendering as well, so no environment guard is needed inside the `$derived`.

Server-rendered output is unchanged: `selectedCommons` is empty during SSR and `buildShareUrl` already returns `""` for an empty selection, so the share button stays hidden exactly as before.

Two assertions were added to `page.url-reactivity.test.ts`. Together they fail if `shareUrl` goes back to being assigned inside an `$effect`, or if the derivation goes back to reading `window.location.origin`. The pre-existing `$effect` count assertion was lowered from `>= 3` to `>= 2` to match the removed effect.

## Confirmation

Ran the site test suite (296 tests), type-check, `svelte-check`, and biome locally; all passed. Both new assertions were verified to fail when the corresponding old form is restored.

## Limitation

The share button rendering was covered by tests only; it was not manually verified in a real browser.

https://claude.ai/code/session_01UUXFugio28xcAFbtnLT4mT
