### PR TITLE
refactor: route goto() navigation targets through resolve()

### DIFF
--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -5,6 +5,7 @@
 	import { Plus, Shuffle } from "lucide-svelte";
 	import { onMount } from "svelte";
 	import { goto } from "$app/navigation";
+	import { resolve } from "$app/paths";
 	import { page } from "$app/state";
 	import AppMenu from "$lib/app-menu/AppMenu.svelte";
 	import Card from "$lib/Card.svelte";
@@ -110,12 +111,12 @@
 	 *
 	 * We gate on `restored` rather than running on mount: before onMount seeds
 	 * state the effect would see empty state against a populated URL and navigate
-	 * the preferences away. We hand `goto` the whole URL object, not just its
-	 * search, so the hash survives and an empty query still navigates to the bare
-	 * path instead of being a no-op. Comparing the rebuilt search against the
-	 * current one both prevents a navigation loop and lets a stale legacy
-	 * pin/exclude param get rewritten away. replaceState keeps rapid toggles out
-	 * of the history that draws push onto.
+	 * the preferences away. The target carries the rebuilt search and hash rather
+	 * than the resolved path alone, so the hash survives and an empty query still
+	 * navigates to the bare path instead of being a no-op. Comparing the rebuilt
+	 * search against the current one both prevents a navigation loop and lets a
+	 * stale legacy pin/exclude param get rewritten away. replaceState keeps rapid
+	 * toggles out of the history that draws push onto.
 	 */
 	$effect(() => {
 		if (!restored) {
@@ -131,7 +132,11 @@
 			return;
 		}
 
-		goto(nextUrl, { replaceState: true, keepFocus: true, noScroll: true });
+		goto(`${resolve("/")}${nextUrl.search}${nextUrl.hash}`, {
+			replaceState: true,
+			keepFocus: true,
+			noScroll: true,
+		});
 	});
 
 	function drawRandomCards() {
@@ -171,7 +176,7 @@
 	}
 
 	function navigateWithCardState() {
-		goto(buildCardUrl(selectedCommons, page.url.searchParams), {
+		goto(`${resolve("/")}${buildCardUrl(selectedCommons, page.url.searchParams)}`, {
 			keepFocus: true,
 			noScroll: true,
 		});

--- a/packages/site/src/routes/+page.svelte
+++ b/packages/site/src/routes/+page.svelte
@@ -155,10 +155,7 @@
 		selectedCommons = result.cards;
 		errorMessage = "";
 
-		goto(buildCardUrl(selectedCommons, page.url.searchParams), {
-			keepFocus: true,
-			noScroll: true,
-		});
+		navigateWithCardState();
 	}
 
 	async function copyToClipboard() {


### PR DESCRIPTION
## Summary

Route the `goto()` navigation targets in `+page.svelte` through `resolve()` from `$app/paths`.

Rebased onto `main`: the three lower commits of the original stack have landed, so this branch now holds two commits touching a single file.

## Details

Recent SvelteKit recommends resolving navigation targets with `resolve()` so a configured base path is applied consistently; bare query strings and URL objects bypass that.

`drawRandomCards` and `navigateWithCardState` already built an identical target, so the first commit makes `drawRandomCards` call the helper. That leaves a single place for the `resolve()` change to land instead of two that could diverge.

The preference-mirroring effect appends the rebuilt search and hash to the resolved path rather than navigating to that path alone, because the hash must survive and an empty query must still navigate.

## Confirmation

Ran the site test suite (296 tests) and `pnpm check` locally; all passed, with `svelte-check` reporting 0 errors and 0 warnings.

## Limitation

The app currently has a single route and no base path, so this changes no observable behavior today.

https://claude.ai/code/session_01A5aYbMgFYUGdkGBMNox4AX
