### PR TITLE
refactor: add keys to remaining each blocks

### DIFF
--- a/packages/site/src/lib/Card.svelte
+++ b/packages/site/src/lib/Card.svelte
@@ -72,7 +72,7 @@
 	}}
 >
 	<div class="card-strip">
-		{#each categoryLabels as cat}
+		{#each categoryLabels as cat (cat.label)}
 			<div
 				class="card-strip-segment"
 				style:background-color={cat.color}
@@ -82,7 +82,7 @@
 
 	<div class="card-body">
 		<span class="card-categories">
-			{#each categoryLabels as cat}
+			{#each categoryLabels as cat (cat.label)}
 				<span
 					class="card-category"
 					style:color={cat.color}>{cat.label}</span
@@ -105,7 +105,7 @@
 			{#if linkCount === 0}
 				<span class="card-link-dot card-link-dot--gray"></span>
 			{:else}
-				{#each Array(linkCount) as _}
+				{#each Array(linkCount) as _, i (i)}
 					<span class="card-link-dot"></span>
 				{/each}
 			{/if}

--- a/packages/site/src/lib/CardDetail.svelte
+++ b/packages/site/src/lib/CardDetail.svelte
@@ -85,7 +85,7 @@
 	<div class="detail-content">
 		<div class="detail-header">
 			<h2 class="detail-title">{card.name}</h2>
-			{#each categoryLabels as cat}
+			{#each categoryLabels as cat (cat.label)}
 				<span
 					class="detail-dot"
 					style:background-color={cat.color}
@@ -102,7 +102,7 @@
 		</div>
 
 		<div class="detail-meta">
-			{#each categoryLabels as cat}
+			{#each categoryLabels as cat (cat.label)}
 				<span
 					class="detail-badge detail-badge--category"
 					style:background-color={cat.color}

--- a/packages/site/src/lib/ExcludeList.svelte
+++ b/packages/site/src/lib/ExcludeList.svelte
@@ -53,14 +53,14 @@
 				{@const categories = getCategoryLabels(card)}
 				<div class="exclude-row">
 					<div class="exclude-strip">
-						{#each categories as cat}
+						{#each categories as cat (cat.label)}
 							<div
 								class="exclude-strip-segment"
 								style:background-color={cat.color}
 							></div>
 						{/each}
 					</div>
-					{#each categories as cat}
+					{#each categories as cat (cat.label)}
 						<span
 							class="exclude-category"
 							style:color={cat.color}>{cat.label}</span


### PR DESCRIPTION
## Summary

Add keys to the remaining unkeyed `{#each}` blocks in `Card`, `CardDetail`, and `ExcludeList`.

## Details

Unkeyed each blocks make Svelte patch items positionally, which can carry stale DOM state across reorders and is flagged by the Svelte autofixer.

Category labels are unique per card, so the label serves as the key; the link-dot loop renders an index range, so the index is the only identity available.

## Confirmation

Ran the full monorepo test suite (515 tests across 5 packages), type-check, and biome locally; all passed, and the Svelte autofixer reports no remaining issues on the touched components.

## Limitation

No known limitations.

https://claude.ai/code/session_01UUXFugio28xcAFbtnLT4mT


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved restoration of pinned, excluded, and enabled filters from shared or bookmarked URLs.
  - Preserved URL query parameters and hash fragments during navigation and preference updates.
  - Improved synchronization between page state and the browser URL.
  - Enhanced consistency when updating card selections and constraints.
- **Quality Improvements**
  - Improved rendering stability for category labels, color strips, and link indicators.
  - Strengthened coverage for URL synchronization, state restoration, and filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->