### PR TITLE
chore: migrate the biome linter preset field

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -17,7 +17,7 @@
   "linter": {
     "enabled": true,
     "rules": {
-      "recommended": true,
+      "preset": "recommended",
       "style": {
         "noParameterAssign": "error",
         "useAsConstAssertion": "error",


### PR DESCRIPTION
## Summary

Rename `linter.rules.recommended` to `linter.rules.preset` in `biome.json`.

## Details

Biome deprecated the `recommended` field and will drop it in the next major, so the config emitted a diagnostic on every run.

The rename was applied with `biome migrate --write` rather than by hand, so it follows whatever the installed release defines.

This sits on top of #2129 because that PR is what made the diagnostic visible: before it, no biome run covered `biome.json` itself.

## Confirmation

`biome ci .` reports 146 files and no diagnostics, where it previously reported one info.

`pnpm check` and `pnpm fmt` each exit 0.

## Limitation

No known limitations.

https://claude.ai/code/session_01A5aYbMgFYUGdkGBMNox4AX

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
